### PR TITLE
comment out windows workflow

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       matrix:
         version:
-          - {macos: macos-13, python: '3.10'}
           - {macos: macos-14, python: '3.10'}
+          - {macos: macos-15, python: '3.14'}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - {macos: macos-14, python: '3.10'}
+          - {macos: macos-14, python: '3.14'}
           - {macos: macos-15, python: '3.14'}
     steps:
       - name: Clone repository

--- a/.github/workflows/misc/cplex2211_windows_installer.properties
+++ b/.github/workflows/misc/cplex2211_windows_installer.properties
@@ -36,7 +36,7 @@ CPLEX_STUDIO_FILE_ASSOCIATION=0
 CPLEX_STUDIO_PATH_UPDATE=1
 
 #Silent Installation
-#INSTALLER_UI=silent
+INSTALLER_UI=silent
 
 #Install
 #------------

--- a/.github/workflows/misc/cplex2211_windows_installer.properties
+++ b/.github/workflows/misc/cplex2211_windows_installer.properties
@@ -36,7 +36,7 @@ CPLEX_STUDIO_FILE_ASSOCIATION=0
 CPLEX_STUDIO_PATH_UPDATE=1
 
 #Silent Installation
-INSTALLER_UI=silent
+#INSTALLER_UI=silent
 
 #Install
 #------------

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,8 +28,12 @@ jobs:
         platform:
           # The compiler used by the runner for Windows 2022 and Windows 2025 is
           # the same. We could just run tests on Windows 2025 but there the silent
-          # CPLEX installation fails. We thus only test on 2022.
-          - {os: "windows-2025", vc: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"}
+          # CPLEX installation times out without an error message. We tested that
+          # the disk where we plan to install CPLEX is available, has enough space
+          # we could create a test file on it. It is unclear if the installer does
+          # something and is just slow, or if it does nothing because of some error.
+          # We thus only test on Windows 2022 for now.
+          # - {os: "windows-2025", vc: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"}
           - {os: "windows-2022", vc: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"}
         python-version: [3.8]
     steps:
@@ -73,11 +77,6 @@ jobs:
           echo "For information about the CPLEX silent installation consult:"
           echo "https://www.ibm.com/docs/en/icos/22.1.1?topic=2211-silent-installation-cplex-optimization-studio"
           curl.exe --output cplex.exe $ENV:CPLEX_URL
-
-          echo "Testing write"
-          New-Item -Path D:\\a\\cplex_temp -ItemType Directory -Force
-          "Hello world" | Set-Content -Path D:\\a\\cplex_temp\\foo -Force
-          Get-Content -Path D:\\a\\cplex_temp\\foo
 
           echo "Install CPLEX"
           Start-Process -FilePath .\cplex.exe -ArgumentList "-f", "$ENV:GITHUB_WORKSPACE\.github\workflows\misc\cplex2211_windows_installer.properties" -PassThru | Wait-Process

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,9 +26,11 @@ jobs:
     strategy:
       matrix:
         platform:
-          - {os: "windows-2025", vc: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"}
-          # We do not test on Windows 2022 at the moment because the compiler that runner uses is the same as the one for Windows 2025.
-          # - {os: "windows-2022", vc: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"}
+          # The compiler used by the runner for Windows 2022 and Windows 2025 is
+          # the same. We could just run tests on Windows 2025 but there the silent
+          # CPLEX installation fails. We thus only test on 2022.
+          # - {os: "windows-2025", vc: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"}
+          - {os: "windows-2022", vc: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"}
         python-version: [3.8]
     steps:
       - name: Clone repository
@@ -72,8 +74,6 @@ jobs:
           echo "https://www.ibm.com/docs/en/icos/22.1.1?topic=2211-silent-installation-cplex-optimization-studio"
           curl.exe --output cplex.exe $ENV:CPLEX_URL
 
-          echo "Executing CPLEX Installer"
-          Start-Process -FilePath .\cplex.exe -PassThru | Wait-Process
           echo "Install CPLEX"
           Start-Process -FilePath .\cplex.exe -ArgumentList "-f", "$ENV:GITHUB_WORKSPACE\.github\workflows\misc\cplex2211_windows_installer.properties" -PassThru | Wait-Process
           del .\cplex.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -73,7 +73,7 @@ jobs:
           curl.exe --output cplex.exe $ENV:CPLEX_URL
 
           echo "Executing CPLEX Installer"
-          .\cplex.exe
+          Start-Process -FilePath .\cplex.exe -PassThru | Wait-Process
           echo "Install CPLEX"
           Start-Process -FilePath .\cplex.exe -ArgumentList "-f", "$ENV:GITHUB_WORKSPACE\.github\workflows\misc\cplex2211_windows_installer.properties" -PassThru | Wait-Process
           del .\cplex.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -74,10 +74,12 @@ jobs:
           echo "https://www.ibm.com/docs/en/icos/22.1.1?topic=2211-silent-installation-cplex-optimization-studio"
           curl.exe --output cplex.exe $ENV:CPLEX_URL
 
+          echo "Testing write"
+          New-Item -Path D:\\a\\cplex_temp -ItemType Directory -Force
+          "Hello world" | Set-Content -Path D:\\a\\cplex_temp\\foo -Force
+          Get-Content -Path D:\\a\\cplex_temp\\foo
+
           echo "Install CPLEX"
-
-          Get-WmiObject -Class Win32_LogicalDisk | Select-Object -Property DeviceID, VolumeName, @{Label='FreeSpace (Gb)'; expression={($_.FreeSpace/1GB).ToString('F2')}}, @{Label='Total (Gb)'; expression={($_.Size/1GB).ToString('F2')}}, @{label='FreePercent'; expression={[Math]::Round(($_.freespace / $_.size) * 100, 2)}}|ft
-
           Start-Process -FilePath .\cplex.exe -ArgumentList "-f", "$ENV:GITHUB_WORKSPACE\.github\workflows\misc\cplex2211_windows_installer.properties" -PassThru | Wait-Process
           del .\cplex.exe
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,7 +29,7 @@ jobs:
           # The compiler used by the runner for Windows 2022 and Windows 2025 is
           # the same. We could just run tests on Windows 2025 but there the silent
           # CPLEX installation fails. We thus only test on 2022.
-          # - {os: "windows-2025", vc: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"}
+          - {os: "windows-2025", vc: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"}
           - {os: "windows-2022", vc: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"}
         python-version: [3.8]
     steps:
@@ -75,6 +75,9 @@ jobs:
           curl.exe --output cplex.exe $ENV:CPLEX_URL
 
           echo "Install CPLEX"
+
+          Get-WmiObject -Class Win32_LogicalDisk | Select-Object -Property DeviceID, VolumeName, @{Label='FreeSpace (Gb)'; expression={($_.FreeSpace/1GB).ToString('F2')}}, @{Label='Total (Gb)'; expression={($_.Size/1GB).ToString('F2')}}, @{label='FreePercent'; expression={[Math]::Round(($_.freespace / $_.size) * 100, 2)}}|ft
+
           Start-Process -FilePath .\cplex.exe -ArgumentList "-f", "$ENV:GITHUB_WORKSPACE\.github\workflows\misc\cplex2211_windows_installer.properties" -PassThru | Wait-Process
           del .\cplex.exe
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -73,6 +73,9 @@ jobs:
           curl.exe --output cplex.exe $ENV:CPLEX_URL
 
           echo "Install CPLEX"
+          type $ENV:GITHUB_WORKSPACE\.github\workflows\misc\cplex2211_windows_installer.properties
+          .\cplex.exe -h
+          .\cplex.exe -f $ENV:GITHUB_WORKSPACE\.github\workflows\misc\cplex2211_windows_installer.properties
           Start-Process -FilePath .\cplex.exe -ArgumentList "-f", "$ENV:GITHUB_WORKSPACE\.github\workflows\misc\cplex2211_windows_installer.properties" -PassThru | Wait-Process
           del .\cplex.exe
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -72,10 +72,9 @@ jobs:
           echo "https://www.ibm.com/docs/en/icos/22.1.1?topic=2211-silent-installation-cplex-optimization-studio"
           curl.exe --output cplex.exe $ENV:CPLEX_URL
 
+          echo "Executing CPLEX Installer"
+          .\cplex.exe
           echo "Install CPLEX"
-          type $ENV:GITHUB_WORKSPACE\.github\workflows\misc\cplex2211_windows_installer.properties
-          .\cplex.exe -h
-          .\cplex.exe -f $ENV:GITHUB_WORKSPACE\.github\workflows\misc\cplex2211_windows_installer.properties
           Start-Process -FilePath .\cplex.exe -ArgumentList "-f", "$ENV:GITHUB_WORKSPACE\.github\workflows\misc\cplex2211_windows_installer.properties" -PassThru | Wait-Process
           del .\cplex.exe
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,7 +35,7 @@ jobs:
           # We thus only test on Windows 2022 for now.
           # - {os: "windows-2025", vc: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"}
           - {os: "windows-2022", vc: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"}
-        python-version: [3.8]
+        python-version: [3.9]
     steps:
       - name: Clone repository
         uses: actions/checkout@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,8 +26,9 @@ jobs:
     strategy:
       matrix:
         platform:
-          - {os: "windows-2022", vc: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"}
-          - {os: "windows-2019", vc: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"}
+          - {os: "windows-2025", vc: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"}
+          # We do not test on Windows 2022 at the moment because the compiler that runner uses is the same as the one for Windows 2025.
+          # - {os: "windows-2022", vc: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat"}
         python-version: [3.8]
     steps:
       - name: Clone repository

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ not supported under Windows either.
 
 This version of Fast Downward has been tested with the following software versions:
 
-| OS           | Python | C++ compiler                                                     | CMake |
-| ------------ | ------ | ---------------------------------------------------------------- | ----- |
-| Ubuntu 24.04 | 3.10   | GCC 14, Clang 18                                                 | 3.30  |
-| Ubuntu 22.04 | 3.10   | GCC 12                                                           | 3.30  |
-| macOS 14     | 3.10   | AppleClang 15                                                    | 3.30  |
-| macOS 13     | 3.10   | AppleClang 15                                                    | 3.30  |
-| Windows 10   | 3.8    | Visual Studio Enterprise 2019 (MSVC 19.29) and 2022 (MSVC 19.41) | 3.30  |
+| OS           | Python | C++ compiler                               | CMake |
+| ------------ | ------ | ------------------------------------------ | ----- |
+| Ubuntu 24.04 | 3.10   | GCC 14, Clang 18                           | 3.31  |
+| Ubuntu 22.04 | 3.10   | GCC 12                                     | 3.31  |
+| macOS 15     | 3.14   | AppleClang 17                              | 4.2   |
+| macOS 14     | 3.14   | AppleClang 15                              | 4.2   |
+| Windows 10   | 3.9    | Visual Studio Enterprise 2022 (MSVC 19.44) | 3.31  |
 
 We test LP support with CPLEX 22.1.1 and SoPlex 7.1.1. On Ubuntu we
 test both CPLEX and SoPlex. On Windows we currently only test CPLEX,


### PR DESCRIPTION
[targeting my own repo with the PR, as CPLEX is not tested on external PRs]

The Windows 2019 worker is no longer supported, so we have to remove it.
Github offers two newer workers (2022 and 2025) but they both use the same version of Visual Studio. We thus only want to run on Windows 2025 for now.

The last time we tested this, the build timed out while installing CPLEX. For now we check if this is still an issue.
