### PR TITLE
Issue559 - part 3

### DIFF
--- a/src/search/cartesian_abstractions/additive_cartesian_heuristic.cc
+++ b/src/search/cartesian_abstractions/additive_cartesian_heuristic.cc
@@ -2,6 +2,7 @@
 
 #include "cartesian_heuristic_function.h"
 #include "cost_saturation.h"
+#include "subtask_generators.h"
 #include "types.h"
 #include "utils.h"
 
@@ -17,10 +18,10 @@ using namespace std;
 
 namespace cartesian_abstractions {
 static vector<CartesianHeuristicFunction> generate_heuristic_functions(
+    const shared_ptr<AbstractTask> &task,
     const vector<shared_ptr<SubtaskGenerator>> &subtask_generators,
     int max_states, int max_transitions, double max_time, PickSplit pick,
-    bool use_general_costs, int random_seed,
-    const shared_ptr<AbstractTask> &transform, utils::LogProxy &log) {
+    bool use_general_costs, int random_seed, utils::LogProxy &log) {
     if (log.is_at_least_normal()) {
         log << "Initializing additive Cartesian heuristic..." << endl;
     }
@@ -28,19 +29,19 @@ static vector<CartesianHeuristicFunction> generate_heuristic_functions(
     CostSaturation cost_saturation(
         subtask_generators, max_states, max_transitions, max_time, pick,
         use_general_costs, *rng, log);
-    return cost_saturation.generate_heuristic_functions(transform);
+    return cost_saturation.generate_heuristic_functions(task);
 }
 
 AdditiveCartesianHeuristic::AdditiveCartesianHeuristic(
+    const shared_ptr<AbstractTask> &task,
     const vector<shared_ptr<SubtaskGenerator>> &subtasks, int max_states,
     int max_transitions, double max_time, PickSplit pick,
-    bool use_general_costs, int random_seed,
-    const shared_ptr<AbstractTask> &transform, bool cache_estimates,
+    bool use_general_costs, int random_seed, bool cache_estimates,
     const string &description, utils::Verbosity verbosity)
-    : Heuristic(transform, cache_estimates, description, verbosity),
+    : Heuristic(task, cache_estimates, description, verbosity),
       heuristic_functions(generate_heuristic_functions(
-          subtasks, max_states, max_transitions, max_time, pick,
-          use_general_costs, random_seed, transform, log)) {
+          task, subtasks, max_states, max_transitions, max_time, pick,
+          use_general_costs, random_seed, log)) {
 }
 
 int AdditiveCartesianHeuristic::compute_heuristic(const State &ancestor_state) {
@@ -58,9 +59,9 @@ int AdditiveCartesianHeuristic::compute_heuristic(const State &ancestor_state) {
 }
 
 class AdditiveCartesianHeuristicFeature
-    : public plugins::TypedFeature<Evaluator, AdditiveCartesianHeuristic> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    AdditiveCartesianHeuristicFeature() : TypedFeature("cegar") {
+    AdditiveCartesianHeuristicFeature() : TaskIndependentFeature("cegar") {
         document_title("Additive Cartesian CEGAR heuristic");
         document_synopsis(
             "See the paper introducing counterexample-guided Cartesian "
@@ -90,7 +91,7 @@ public:
                 "Journal of Artificial Intelligence Research", "62", "535-577",
                 "2018"));
 
-        add_list_option<shared_ptr<SubtaskGenerator>>(
+        add_list_option<shared_ptr<TaskIndependentSubtaskGenerator>>(
             "subtasks", "subtask generators", "[landmarks(),goals()]");
         add_option<int>(
             "max_states",
@@ -123,10 +124,10 @@ public:
         document_property("preferred operators", "no");
     }
 
-    virtual shared_ptr<AdditiveCartesianHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<AdditiveCartesianHeuristic>(
-            opts.get_list<shared_ptr<SubtaskGenerator>>("subtasks"),
+        return components::make_auto_task_independent_component<AdditiveCartesianHeuristic, Evaluator>(
+            opts.get_list<shared_ptr<TaskIndependentSubtaskGenerator>>("subtasks"),
             opts.get<int>("max_states"), opts.get<int>("max_transitions"),
             opts.get<double>("max_time"), opts.get<PickSplit>("pick"),
             opts.get<bool>("use_general_costs"),

--- a/src/search/cartesian_abstractions/additive_cartesian_heuristic.h
+++ b/src/search/cartesian_abstractions/additive_cartesian_heuristic.h
@@ -21,11 +21,12 @@ protected:
     virtual int compute_heuristic(const State &ancestor_state) override;
 
 public:
-    explicit AdditiveCartesianHeuristic(
+    AdditiveCartesianHeuristic(
+        const std::shared_ptr<AbstractTask> &task,
         const std::vector<std::shared_ptr<SubtaskGenerator>> &subtasks,
         int max_states, int max_transitions, double max_time, PickSplit pick,
         bool use_general_costs, int random_seed,
-        const std::shared_ptr<AbstractTask> &transform, bool cache_estimates,
+        bool cache_estimates,
         const std::string &description, utils::Verbosity verbosity);
 };
 }

--- a/src/search/cartesian_abstractions/split_selector.cc
+++ b/src/search/cartesian_abstractions/split_selector.cc
@@ -19,7 +19,8 @@ SplitSelector::SplitSelector(
     : task(task), task_proxy(*task), pick(pick) {
     if (pick == PickSplit::MIN_HADD || pick == PickSplit::MAX_HADD) {
         additive_heuristic = make_unique<additive_heuristic::AdditiveHeuristic>(
-            tasks::AxiomHandlingType::APPROXIMATE_NEGATIVE, task, false,
+            task,
+            tasks::AxiomHandlingType::APPROXIMATE_NEGATIVE, false,
             "h^add within CEGAR abstractions", utils::Verbosity::SILENT);
         additive_heuristic->compute_heuristic_for_cegar(
             task_proxy.get_initial_state());

--- a/src/search/cartesian_abstractions/subtask_generators.cc
+++ b/src/search/cartesian_abstractions/subtask_generators.cc
@@ -35,7 +35,8 @@ public:
     explicit SortFactsByIncreasingHaddValues(
         const shared_ptr<AbstractTask> &task)
         : hadd(make_unique<additive_heuristic::AdditiveHeuristic>(
-              tasks::AxiomHandlingType::APPROXIMATE_NEGATIVE, task, false,
+              task,
+              tasks::AxiomHandlingType::APPROXIMATE_NEGATIVE, false,
               "h^add within CEGAR abstractions", utils::Verbosity::SILENT)) {
         TaskProxy task_proxy(*task);
         hadd->compute_heuristic_for_cegar(task_proxy.get_initial_state());
@@ -93,7 +94,11 @@ static Facts filter_and_order_facts(
     return facts;
 }
 
-TaskDuplicator::TaskDuplicator(int copies) : num_copies(copies) {
+SubtaskGenerator::SubtaskGenerator(const shared_ptr<AbstractTask> &task)
+    : components::TaskSpecificComponent(task) {
+}
+
+TaskDuplicator::TaskDuplicator(const shared_ptr<AbstractTask> &task, int copies) : SubtaskGenerator(task), num_copies(copies) {
 }
 
 SharedTasks TaskDuplicator::get_subtasks(
@@ -106,8 +111,8 @@ SharedTasks TaskDuplicator::get_subtasks(
     return subtasks;
 }
 
-GoalDecomposition::GoalDecomposition(FactOrder order, int random_seed)
-    : fact_order(order), rng(utils::get_rng(random_seed)) {
+GoalDecomposition::GoalDecomposition(const shared_ptr<AbstractTask> &task, FactOrder order, int random_seed)
+    : SubtaskGenerator(task), fact_order(order), rng(utils::get_rng(random_seed)) {
 }
 
 SharedTasks GoalDecomposition::get_subtasks(
@@ -125,8 +130,8 @@ SharedTasks GoalDecomposition::get_subtasks(
 }
 
 LandmarkDecomposition::LandmarkDecomposition(
-    FactOrder order, int random_seed, bool combine_facts)
-    : fact_order(order),
+    const shared_ptr<AbstractTask> &task, FactOrder order, int random_seed, bool combine_facts)
+    : SubtaskGenerator(task), fact_order(order),
       combine_facts(combine_facts),
       rng(utils::get_rng(random_seed)) {
 }
@@ -180,9 +185,9 @@ static tuple<FactOrder, int> get_fact_order_arguments_from_options(
 }
 
 class TaskDuplicatorFeature
-    : public plugins::TypedFeature<SubtaskGenerator, TaskDuplicator> {
+    : public plugins::TaskIndependentFeature<TaskIndependentSubtaskGenerator> {
 public:
-    TaskDuplicatorFeature() : TypedFeature("original") {
+    TaskDuplicatorFeature() : TaskIndependentFeature("original") {
         document_title("No abstraction");
         document_synopsis(
             "Copies of the original task are used as subproblems.");
@@ -191,9 +196,9 @@ public:
             plugins::Bounds("1", "infinity"));
     }
 
-    virtual shared_ptr<TaskDuplicator> create_component(
+    virtual shared_ptr<TaskIndependentSubtaskGenerator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<TaskDuplicator>(
+        return components::make_auto_task_independent_component<TaskDuplicator, SubtaskGenerator>(
             opts.get<int>("copies"));
     }
 };
@@ -201,18 +206,18 @@ public:
 static plugins::FeaturePlugin<TaskDuplicatorFeature> _plugin_original;
 
 class GoalDecompositionFeature
-    : public plugins::TypedFeature<SubtaskGenerator, GoalDecomposition> {
+    : public plugins::TaskIndependentFeature<TaskIndependentSubtaskGenerator> {
 public:
-    GoalDecompositionFeature() : TypedFeature("goals") {
+    GoalDecompositionFeature() : TaskIndependentFeature("goals") {
         document_title("Abstraction by goals");
         document_synopsis(
             "For each goal atom of the original task one subproblem is generated having only the atom as its goal.");
         add_fact_order_option(*this);
     }
 
-    virtual shared_ptr<GoalDecomposition> create_component(
+    virtual shared_ptr<TaskIndependentSubtaskGenerator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<GoalDecomposition>(
+        return components::make_auto_task_independent_component<GoalDecomposition, SubtaskGenerator>(
             get_fact_order_arguments_from_options(opts));
     }
 };
@@ -220,9 +225,9 @@ public:
 static plugins::FeaturePlugin<GoalDecompositionFeature> _plugin_goals;
 
 class LandmarkDecompositionFeature
-    : public plugins::TypedFeature<SubtaskGenerator, LandmarkDecomposition> {
+    : public plugins::TaskIndependentFeature<TaskIndependentSubtaskGenerator> {
 public:
-    LandmarkDecompositionFeature() : TypedFeature("landmarks") {
+    LandmarkDecompositionFeature() : TaskIndependentFeature("landmarks") {
         document_title("Abstraction by landmarks");
         document_synopsis(
             "For each fact landmark of the delete relaxation of the original task one subproblem is generated having only the landmark as goal. This is a generalization of abstractions by goals.");
@@ -232,9 +237,9 @@ public:
             "true");
     }
 
-    virtual shared_ptr<LandmarkDecomposition> create_component(
+    virtual shared_ptr<TaskIndependentSubtaskGenerator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<LandmarkDecomposition>(
+        return components::make_auto_task_independent_component<LandmarkDecomposition, SubtaskGenerator>(
             get_fact_order_arguments_from_options(opts),
             opts.get<bool>("combine_facts"));
     }
@@ -243,7 +248,7 @@ public:
 static plugins::FeaturePlugin<LandmarkDecompositionFeature> _plugin_landmarks;
 
 static class SubtaskGeneratorCategoryPlugin
-    : public plugins::TypedCategoryPlugin<SubtaskGenerator> {
+    : public plugins::TypedCategoryPlugin<TaskIndependentSubtaskGenerator> {
 public:
     SubtaskGeneratorCategoryPlugin() : TypedCategoryPlugin("SubtaskGenerator") {
         document_synopsis(

--- a/src/search/cartesian_abstractions/subtask_generators.h
+++ b/src/search/cartesian_abstractions/subtask_generators.h
@@ -1,6 +1,8 @@
 #ifndef CARTESIAN_ABSTRACTIONS_SUBTASK_GENERATORS_H
 #define CARTESIAN_ABSTRACTIONS_SUBTASK_GENERATORS_H
 
+#include "../component.h"
+
 #include <memory>
 #include <vector>
 
@@ -34,13 +36,16 @@ enum class FactOrder {
 /*
   Create focused subtasks.
 */
-class SubtaskGenerator {
+class SubtaskGenerator : public components::TaskSpecificComponent {
 public:
+    explicit SubtaskGenerator(const std::shared_ptr<AbstractTask> &task);
     virtual SharedTasks get_subtasks(
         const std::shared_ptr<AbstractTask> &task,
         utils::LogProxy &log) const = 0;
-    virtual ~SubtaskGenerator() = default;
 };
+
+using TaskIndependentSubtaskGenerator =
+    components::TaskIndependentComponent<SubtaskGenerator>;
 
 /*
   Return copies of the original task.
@@ -49,7 +54,7 @@ class TaskDuplicator : public SubtaskGenerator {
     int num_copies;
 
 public:
-    explicit TaskDuplicator(int copies);
+    TaskDuplicator(const std::shared_ptr<AbstractTask> &task, int copies);
 
     virtual SharedTasks get_subtasks(
         const std::shared_ptr<AbstractTask> &task,
@@ -64,7 +69,7 @@ class GoalDecomposition : public SubtaskGenerator {
     std::shared_ptr<utils::RandomNumberGenerator> rng;
 
 public:
-    explicit GoalDecomposition(FactOrder order, int random_seed);
+    GoalDecomposition(const std::shared_ptr<AbstractTask> &task, FactOrder order, int random_seed);
 
     virtual SharedTasks get_subtasks(
         const std::shared_ptr<AbstractTask> &task,
@@ -87,7 +92,8 @@ class LandmarkDecomposition : public SubtaskGenerator {
         const landmarks::LandmarkNode *node) const;
 
 public:
-    explicit LandmarkDecomposition(
+    LandmarkDecomposition(
+        const std::shared_ptr<AbstractTask> &task,
         FactOrder order, int random_seed, bool combine_facts);
 
     virtual SharedTasks get_subtasks(

--- a/src/search/cartesian_abstractions/utils_landmarks.cc
+++ b/src/search/cartesian_abstractions/utils_landmarks.cc
@@ -25,7 +25,7 @@ static FactPair get_atom(const Landmark &landmark) {
 shared_ptr<LandmarkGraph> get_landmark_graph(
     const shared_ptr<AbstractTask> &task) {
     LandmarkFactoryHM landmark_graph_factory(
-        1, false, true, utils::Verbosity::SILENT);
+        task, 1, false, true, utils::Verbosity::SILENT);
 
     return landmark_graph_factory.compute_landmark_graph(task);
 }

--- a/src/search/evaluator.cc
+++ b/src/search/evaluator.cc
@@ -9,10 +9,11 @@
 using namespace std;
 
 Evaluator::Evaluator(
+    const shared_ptr<AbstractTask> &task,
     bool use_for_reporting_minima, bool use_for_boosting,
     bool use_for_counting_evaluations, const string &description,
     utils::Verbosity verbosity)
-    : description(description),
+    : components::TaskSpecificComponent(task), description(description),
       use_for_reporting_minima(use_for_reporting_minima),
       use_for_boosting(use_for_boosting),
       use_for_counting_evaluations(use_for_counting_evaluations),
@@ -87,10 +88,10 @@ tuple<string, utils::Verbosity> get_evaluator_arguments_from_options(
         utils::get_log_arguments_from_options(opts));
 }
 
-static class EvaluatorCategoryPlugin
-    : public plugins::TypedCategoryPlugin<Evaluator> {
+static class TaskIndependentEvaluatorCategoryPlugin
+    : public plugins::TypedCategoryPlugin<TaskIndependentEvaluator> {
 public:
-    EvaluatorCategoryPlugin() : TypedCategoryPlugin("Evaluator") {
+    TaskIndependentEvaluatorCategoryPlugin() : TypedCategoryPlugin("Evaluator") {
         document_synopsis(
             "An evaluator specification is either a newly created evaluator "
             "instance or an evaluator that has been [defined previously ../search-plugin-syntax.md#variables_as_parameters]. "

--- a/src/search/evaluator.h
+++ b/src/search/evaluator.h
@@ -1,6 +1,7 @@
 #ifndef EVALUATOR_H
 #define EVALUATOR_H
 
+#include "component.h"
 #include "evaluation_result.h"
 
 #include "utils/logging.h"
@@ -14,7 +15,7 @@ namespace plugins {
 class Options;
 }
 
-class Evaluator {
+class Evaluator : public components::TaskSpecificComponent {
     const std::string description;
     const bool use_for_reporting_minima;
     const bool use_for_boosting;
@@ -23,10 +24,10 @@ protected:
     mutable utils::LogProxy log;
 public:
     Evaluator(
+        const std::shared_ptr<AbstractTask> &task,
         bool use_for_reporting_minima, bool use_for_boosting,
         bool use_for_counting_evaluations, const std::string &description,
         utils::Verbosity verbosity);
-    virtual ~Evaluator() = default;
 
     /*
       dead_ends_are_reliable should return true if the evaluator is
@@ -96,6 +97,9 @@ public:
     */
     virtual int get_cached_estimate(const State &state) const;
 };
+
+using TaskIndependentEvaluator =
+    components::TaskIndependentComponent<Evaluator>;
 
 extern void add_evaluator_options_to_feature(
     plugins::Feature &feature, const std::string &description);

--- a/src/search/evaluators/combining_evaluator.cc
+++ b/src/search/evaluators/combining_evaluator.cc
@@ -10,9 +10,10 @@ using namespace std;
 
 namespace combining_evaluator {
 CombiningEvaluator::CombiningEvaluator(
+    const shared_ptr<AbstractTask> &task,
     const vector<shared_ptr<Evaluator>> &evals, const string &description,
     utils::Verbosity verbosity)
-    : Evaluator(false, false, false, description, verbosity),
+    : Evaluator(task, false, false, false, description, verbosity),
       subevaluators(evals) {
     utils::verify_list_not_empty(evals, "evals");
     all_dead_ends_are_reliable = true;
@@ -56,15 +57,15 @@ void CombiningEvaluator::get_path_dependent_evaluators(
 }
 void add_combining_evaluator_options_to_feature(
     plugins::Feature &feature, const string &description) {
-    feature.add_list_option<shared_ptr<Evaluator>>(
+    feature.add_list_option<shared_ptr<TaskIndependentEvaluator>>(
         "evals", "at least one evaluator");
     add_evaluator_options_to_feature(feature, description);
 }
 
-tuple<vector<shared_ptr<Evaluator>>, const string, utils::Verbosity>
+tuple<vector<shared_ptr<TaskIndependentEvaluator>>, const string, utils::Verbosity>
 get_combining_evaluator_arguments_from_options(const plugins::Options &opts) {
     return tuple_cat(
-        make_tuple(opts.get_list<shared_ptr<Evaluator>>("evals")),
+        make_tuple(opts.get_list<shared_ptr<TaskIndependentEvaluator>>("evals")),
         get_evaluator_arguments_from_options(opts));
 }
 }

--- a/src/search/evaluators/combining_evaluator.h
+++ b/src/search/evaluators/combining_evaluator.h
@@ -20,6 +20,7 @@ protected:
     virtual int combine_values(const std::vector<int> &values) = 0;
 public:
     CombiningEvaluator(
+        const std::shared_ptr<AbstractTask> &task,
         const std::vector<std::shared_ptr<Evaluator>> &evals,
         const std::string &description, utils::Verbosity verbosity);
 
@@ -47,7 +48,7 @@ public:
 extern void add_combining_evaluator_options_to_feature(
     plugins::Feature &feature, const std::string &description);
 extern std::tuple<
-    std::vector<std::shared_ptr<Evaluator>>, const std::string,
+    std::vector<std::shared_ptr<TaskIndependentEvaluator>>, const std::string,
     utils::Verbosity>
 get_combining_evaluator_arguments_from_options(const plugins::Options &opts);
 }

--- a/src/search/evaluators/const_evaluator.cc
+++ b/src/search/evaluators/const_evaluator.cc
@@ -6,8 +6,9 @@ using namespace std;
 
 namespace const_evaluator {
 ConstEvaluator::ConstEvaluator(
+    const shared_ptr<AbstractTask> &task,
     int value, const string &description, utils::Verbosity verbosity)
-    : Evaluator(false, false, false, description, verbosity), value(value) {
+    : Evaluator(task, false, false, false, description, verbosity), value(value) {
 }
 
 EvaluationResult ConstEvaluator::compute_result(EvaluationContext &) {
@@ -17,9 +18,9 @@ EvaluationResult ConstEvaluator::compute_result(EvaluationContext &) {
 }
 
 class ConstEvaluatorFeature
-    : public plugins::TypedFeature<Evaluator, ConstEvaluator> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    ConstEvaluatorFeature() : TypedFeature("const") {
+    ConstEvaluatorFeature() : TaskIndependentFeature("const") {
         document_subcategory("evaluators_basic");
         document_title("Constant evaluator");
         document_synopsis("Returns a constant value.");
@@ -30,9 +31,9 @@ public:
         add_evaluator_options_to_feature(*this, "const");
     }
 
-    virtual shared_ptr<ConstEvaluator> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<ConstEvaluator>(
+        return components::make_auto_task_independent_component<ConstEvaluator, Evaluator>(
             opts.get<int>("value"), get_evaluator_arguments_from_options(opts));
     }
 };

--- a/src/search/evaluators/const_evaluator.h
+++ b/src/search/evaluators/const_evaluator.h
@@ -17,6 +17,7 @@ protected:
 
 public:
     ConstEvaluator(
+        const std::shared_ptr<AbstractTask> &task,
         int value, const std::string &description, utils::Verbosity verbosity);
     virtual void get_path_dependent_evaluators(
         std::set<Evaluator *> &) override {

--- a/src/search/evaluators/g_evaluator.cc
+++ b/src/search/evaluators/g_evaluator.cc
@@ -8,8 +8,8 @@
 using namespace std;
 
 namespace g_evaluator {
-GEvaluator::GEvaluator(const string &description, utils::Verbosity verbosity)
-    : Evaluator(false, false, false, description, verbosity) {
+GEvaluator::GEvaluator(const shared_ptr<AbstractTask> &task, const string &description, utils::Verbosity verbosity)
+    : Evaluator(task, false, false, false, description, verbosity) {
 }
 
 EvaluationResult GEvaluator::compute_result(EvaluationContext &eval_context) {
@@ -18,9 +18,9 @@ EvaluationResult GEvaluator::compute_result(EvaluationContext &eval_context) {
     return result;
 }
 
-class GEvaluatorFeature : public plugins::TypedFeature<Evaluator, GEvaluator> {
+class GEvaluatorFeature : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    GEvaluatorFeature() : TypedFeature("g") {
+    GEvaluatorFeature() : TaskIndependentFeature("g") {
         document_subcategory("evaluators_basic");
         document_title("g-value evaluator");
         document_synopsis(
@@ -28,9 +28,9 @@ public:
         add_evaluator_options_to_feature(*this, "g");
     }
 
-    virtual shared_ptr<GEvaluator> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<GEvaluator>(
+        return components::make_auto_task_independent_component<GEvaluator, Evaluator>(
             get_evaluator_arguments_from_options(opts));
     }
 };

--- a/src/search/evaluators/g_evaluator.h
+++ b/src/search/evaluators/g_evaluator.h
@@ -6,7 +6,7 @@
 namespace g_evaluator {
 class GEvaluator : public Evaluator {
 public:
-    GEvaluator(const std::string &description, utils::Verbosity verbosity);
+    GEvaluator(const std::shared_ptr<AbstractTask> &task, const std::string &description, utils::Verbosity verbosity);
 
     virtual EvaluationResult compute_result(
         EvaluationContext &eval_context) override;

--- a/src/search/evaluators/max_evaluator.cc
+++ b/src/search/evaluators/max_evaluator.cc
@@ -8,9 +8,10 @@ using namespace std;
 
 namespace max_evaluator {
 MaxEvaluator::MaxEvaluator(
+    const shared_ptr<AbstractTask> &task,
     const vector<shared_ptr<Evaluator>> &evals, const string &description,
     utils::Verbosity verbosity)
-    : CombiningEvaluator(evals, description, verbosity) {
+    : CombiningEvaluator(task, evals, description, verbosity) {
 }
 
 int MaxEvaluator::combine_values(const vector<int> &values) {
@@ -23,9 +24,9 @@ int MaxEvaluator::combine_values(const vector<int> &values) {
 }
 
 class MaxEvaluatorFeature
-    : public plugins::TypedFeature<Evaluator, MaxEvaluator> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    MaxEvaluatorFeature() : TypedFeature("max") {
+    MaxEvaluatorFeature() : TaskIndependentFeature("max") {
         document_subcategory("evaluators_basic");
         document_title("Max evaluator");
         document_synopsis("Calculates the maximum of the sub-evaluators.");
@@ -33,9 +34,9 @@ public:
             *this, "max");
     }
 
-    virtual shared_ptr<MaxEvaluator> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<MaxEvaluator>(
+        return components::make_auto_task_independent_component<MaxEvaluator, Evaluator>(
             combining_evaluator::get_combining_evaluator_arguments_from_options(
                 opts));
     }

--- a/src/search/evaluators/max_evaluator.h
+++ b/src/search/evaluators/max_evaluator.h
@@ -16,6 +16,7 @@ protected:
 
 public:
     MaxEvaluator(
+        const std::shared_ptr<AbstractTask> &task,
         const std::vector<std::shared_ptr<Evaluator>> &evals,
         const std::string &description, utils::Verbosity verbosity);
 };

--- a/src/search/evaluators/pref_evaluator.cc
+++ b/src/search/evaluators/pref_evaluator.cc
@@ -9,8 +9,9 @@ using namespace std;
 
 namespace pref_evaluator {
 PrefEvaluator::PrefEvaluator(
+    const shared_ptr<AbstractTask> &task,
     const string &description, utils::Verbosity verbosity)
-    : Evaluator(false, false, false, description, verbosity) {
+    : Evaluator(task, false, false, false, description, verbosity) {
 }
 
 EvaluationResult PrefEvaluator::compute_result(
@@ -24,9 +25,9 @@ EvaluationResult PrefEvaluator::compute_result(
 }
 
 class PrefEvaluatorFeature
-    : public plugins::TypedFeature<Evaluator, PrefEvaluator> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    PrefEvaluatorFeature() : TypedFeature("pref") {
+    PrefEvaluatorFeature() : TaskIndependentFeature("pref") {
         document_subcategory("evaluators_basic");
         document_title("Preference evaluator");
         document_synopsis("Returns 0 if preferred is true and 1 otherwise.");
@@ -34,9 +35,9 @@ public:
         add_evaluator_options_to_feature(*this, "pref");
     }
 
-    virtual shared_ptr<PrefEvaluator> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<PrefEvaluator>(
+        return components::make_auto_task_independent_component<PrefEvaluator, Evaluator>(
             get_evaluator_arguments_from_options(opts));
     }
 };

--- a/src/search/evaluators/pref_evaluator.h
+++ b/src/search/evaluators/pref_evaluator.h
@@ -9,7 +9,7 @@
 namespace pref_evaluator {
 class PrefEvaluator : public Evaluator {
 public:
-    PrefEvaluator(const std::string &description, utils::Verbosity verbosity);
+    PrefEvaluator(const std::shared_ptr<AbstractTask> &task, const std::string &description, utils::Verbosity verbosity);
 
     virtual EvaluationResult compute_result(
         EvaluationContext &eval_context) override;

--- a/src/search/evaluators/sum_evaluator.cc
+++ b/src/search/evaluators/sum_evaluator.cc
@@ -8,9 +8,10 @@ using namespace std;
 
 namespace sum_evaluator {
 SumEvaluator::SumEvaluator(
+    const shared_ptr<AbstractTask> &task,
     const vector<shared_ptr<Evaluator>> &evals, const string &description,
     utils::Verbosity verbosity)
-    : CombiningEvaluator(evals, description, verbosity) {
+    : CombiningEvaluator(task, evals, description, verbosity) {
 }
 
 int SumEvaluator::combine_values(const vector<int> &values) {
@@ -24,9 +25,9 @@ int SumEvaluator::combine_values(const vector<int> &values) {
 }
 
 class SumEvaluatorFeature
-    : public plugins::TypedFeature<Evaluator, SumEvaluator> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    SumEvaluatorFeature() : TypedFeature("sum") {
+    SumEvaluatorFeature() : TaskIndependentFeature("sum") {
         document_subcategory("evaluators_basic");
         document_title("Sum evaluator");
         document_synopsis("Calculates the sum of the sub-evaluators.");
@@ -35,9 +36,9 @@ public:
             *this, "sum");
     }
 
-    virtual shared_ptr<SumEvaluator> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<SumEvaluator>(
+        return components::make_auto_task_independent_component<SumEvaluator, Evaluator>(
             combining_evaluator::get_combining_evaluator_arguments_from_options(
                 opts));
     }

--- a/src/search/evaluators/sum_evaluator.h
+++ b/src/search/evaluators/sum_evaluator.h
@@ -16,6 +16,7 @@ protected:
     virtual int combine_values(const std::vector<int> &values) override;
 public:
     SumEvaluator(
+        const std::shared_ptr<AbstractTask> &task,
         const std::vector<std::shared_ptr<Evaluator>> &evals,
         const std::string &description, utils::Verbosity verbosity);
 };

--- a/src/search/evaluators/weighted_evaluator.cc
+++ b/src/search/evaluators/weighted_evaluator.cc
@@ -12,9 +12,10 @@ using namespace std;
 
 namespace weighted_evaluator {
 WeightedEvaluator::WeightedEvaluator(
+    const shared_ptr<AbstractTask> &task,
     const shared_ptr<Evaluator> &eval, int weight, const string &description,
     utils::Verbosity verbosity)
-    : Evaluator(false, false, false, description, verbosity),
+    : Evaluator(task, false, false, false, description, verbosity),
       evaluator(eval),
       weight(weight) {
 }
@@ -41,23 +42,23 @@ void WeightedEvaluator::get_path_dependent_evaluators(set<Evaluator *> &evals) {
 }
 
 class WeightedEvaluatorFeature
-    : public plugins::TypedFeature<Evaluator, WeightedEvaluator> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    WeightedEvaluatorFeature() : TypedFeature("weight") {
+    WeightedEvaluatorFeature() : TaskIndependentFeature("weight") {
         document_subcategory("evaluators_basic");
         document_title("Weighted evaluator");
         document_synopsis(
             "Multiplies the value of the evaluator with the given weight.");
 
-        add_option<shared_ptr<Evaluator>>("eval", "evaluator");
+        add_option<shared_ptr<TaskIndependentEvaluator>>("eval", "evaluator");
         add_option<int>("weight", "weight");
         add_evaluator_options_to_feature(*this, "weight");
     }
 
-    virtual shared_ptr<WeightedEvaluator> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<WeightedEvaluator>(
-            opts.get<shared_ptr<Evaluator>>("eval"), opts.get<int>("weight"),
+        return components::make_auto_task_independent_component<WeightedEvaluator, Evaluator>(
+            opts.get<shared_ptr<TaskIndependentEvaluator>>("eval"), opts.get<int>("weight"),
             get_evaluator_arguments_from_options(opts));
     }
 };

--- a/src/search/evaluators/weighted_evaluator.h
+++ b/src/search/evaluators/weighted_evaluator.h
@@ -16,6 +16,7 @@ class WeightedEvaluator : public Evaluator {
 
 public:
     WeightedEvaluator(
+        const std::shared_ptr<AbstractTask> &task,
         const std::shared_ptr<Evaluator> &eval, int weight,
         const std::string &description, utils::Verbosity verbosity);
 

--- a/src/search/heuristic.cc
+++ b/src/search/heuristic.cc
@@ -14,17 +14,12 @@
 
 using namespace std;
 Heuristic::Heuristic(
-    const shared_ptr<AbstractTask> &transform, bool cache_estimates,
+    const shared_ptr<AbstractTask> &task, bool cache_estimates,
     const string &description, utils::Verbosity verbosity)
-    : Evaluator(true, true, true, description, verbosity),
+    : Evaluator(task, true, true, true, description, verbosity),
       heuristic_cache(
           HEntry(NO_VALUE, true)), // TODO: is true really a good idea here?
-      cache_evaluator_values(cache_estimates),
-      task(transform),
-      task_proxy(*task) {
-}
-
-Heuristic::~Heuristic() {
+      cache_evaluator_values(cache_estimates) {
 }
 
 void Heuristic::set_preferred(const OperatorProxy &op) {
@@ -38,21 +33,15 @@ State Heuristic::convert_ancestor_state(const State &ancestor_state) const {
 
 void add_heuristic_options_to_feature(
     plugins::Feature &feature, const string &description) {
-    feature.add_option<shared_ptr<AbstractTask>>(
-        "transform",
-        "Optional task transformation for the heuristic."
-        " Currently, adapt_costs() and no_transform() are available.",
-        "no_transform()");
     feature.add_option<bool>(
         "cache_estimates", "cache heuristic estimates", "true");
     add_evaluator_options_to_feature(feature, description);
 }
 
-tuple<shared_ptr<AbstractTask>, bool, string, utils::Verbosity>
+tuple<bool, string, utils::Verbosity>
 get_heuristic_arguments_from_options(const plugins::Options &opts) {
     return tuple_cat(
         make_tuple(
-            opts.get<shared_ptr<AbstractTask>>("transform"),
             opts.get<bool>("cache_estimates")),
         get_evaluator_arguments_from_options(opts));
 }

--- a/src/search/heuristic.h
+++ b/src/search/heuristic.h
@@ -53,12 +53,6 @@ protected:
     PerStateInformation<HEntry> heuristic_cache;
     bool cache_evaluator_values;
 
-    // Hold a reference to the task implementation and pass it to objects that
-    // need it.
-    const std::shared_ptr<AbstractTask> task;
-    // Use task_proxy to access task information.
-    TaskProxy task_proxy;
-
     enum {
         DEAD_END = -1,
         NO_VALUE = -2
@@ -77,9 +71,8 @@ protected:
 
 public:
     Heuristic(
-        const std::shared_ptr<AbstractTask> &transform, bool cache_estimates,
+        const std::shared_ptr<AbstractTask> &task, bool cache_estimates,
         const std::string &description, utils::Verbosity verbosity);
-    virtual ~Heuristic() override;
 
     virtual void get_path_dependent_evaluators(
         std::set<Evaluator *> & /*evals*/) override {
@@ -95,7 +88,6 @@ public:
 
 extern void add_heuristic_options_to_feature(
     plugins::Feature &feature, const std::string &description);
-extern std::tuple<
-    std::shared_ptr<AbstractTask>, bool, std::string, utils::Verbosity>
+extern std::tuple<bool, std::string, utils::Verbosity>
 get_heuristic_arguments_from_options(const plugins::Options &opts);
 #endif

--- a/src/search/heuristics/additive_heuristic.cc
+++ b/src/search/heuristics/additive_heuristic.cc
@@ -13,10 +13,10 @@ namespace additive_heuristic {
 const int AdditiveHeuristic::MAX_COST_VALUE;
 
 AdditiveHeuristic::AdditiveHeuristic(
-    tasks::AxiomHandlingType axioms, const shared_ptr<AbstractTask> &transform,
+    const shared_ptr<AbstractTask> &task, tasks::AxiomHandlingType axioms,
     bool cache_estimates, const string &description, utils::Verbosity verbosity)
     : RelaxationHeuristic(
-          axioms, transform, cache_estimates, description, verbosity),
+          task, axioms, cache_estimates, description, verbosity),
       did_write_overflow_warning(false) {
     if (log.is_at_least_normal()) {
         log << "Initializing additive heuristic..." << endl;
@@ -146,9 +146,9 @@ void AdditiveHeuristic::compute_heuristic_for_cegar(const State &state) {
 }
 
 class AdditiveHeuristicFeature
-    : public plugins::TypedFeature<Evaluator, AdditiveHeuristic> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    AdditiveHeuristicFeature() : TypedFeature("add") {
+    AdditiveHeuristicFeature() : TaskIndependentFeature("add") {
         document_title("Additive heuristic");
 
         relaxation_heuristic::add_relaxation_heuristic_options_to_feature(
@@ -164,9 +164,9 @@ public:
         document_property("preferred operators", "yes");
     }
 
-    virtual shared_ptr<AdditiveHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<AdditiveHeuristic>(
+        return components::make_auto_task_independent_component<AdditiveHeuristic, Evaluator>(
             relaxation_heuristic::
                 get_relaxation_heuristic_arguments_from_options(opts));
     }

--- a/src/search/heuristics/additive_heuristic.h
+++ b/src/search/heuristics/additive_heuristic.h
@@ -66,8 +66,8 @@ protected:
     int compute_add_and_ff(const State &state);
 public:
     AdditiveHeuristic(
-        tasks::AxiomHandlingType axioms,
-        const std::shared_ptr<AbstractTask> &transform, bool cache_estimates,
+        const std::shared_ptr<AbstractTask> &task,
+        tasks::AxiomHandlingType axioms, bool cache_estimates,
         const std::string &description, utils::Verbosity verbosity);
 
     /*

--- a/src/search/heuristics/blind_search_heuristic.cc
+++ b/src/search/heuristics/blind_search_heuristic.cc
@@ -12,9 +12,9 @@ using namespace std;
 
 namespace blind_search_heuristic {
 BlindSearchHeuristic::BlindSearchHeuristic(
-    const shared_ptr<AbstractTask> &transform, bool cache_estimates,
+    const shared_ptr<AbstractTask> &task, bool cache_estimates,
     const string &description, utils::Verbosity verbosity)
-    : Heuristic(transform, cache_estimates, description, verbosity),
+    : Heuristic(task, cache_estimates, description, verbosity),
       min_operator_cost(task_properties::get_min_operator_cost(task_proxy)) {
     if (log.is_at_least_normal()) {
         log << "Initializing blind search heuristic..." << endl;
@@ -30,9 +30,9 @@ int BlindSearchHeuristic::compute_heuristic(const State &ancestor_state) {
 }
 
 class BlindSearchHeuristicFeature
-    : public plugins::TypedFeature<Evaluator, BlindSearchHeuristic> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    BlindSearchHeuristicFeature() : TypedFeature("blind") {
+    BlindSearchHeuristicFeature() : TaskIndependentFeature("blind") {
         document_title("Blind heuristic");
         document_synopsis(
             "Returns cost of cheapest action for non-goal states, "
@@ -50,9 +50,9 @@ public:
         document_property("preferred operators", "no");
     }
 
-    virtual shared_ptr<BlindSearchHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<BlindSearchHeuristic>(
+        return components::make_auto_task_independent_component<BlindSearchHeuristic, Evaluator>(
             get_heuristic_arguments_from_options(opts));
     }
 };

--- a/src/search/heuristics/blind_search_heuristic.h
+++ b/src/search/heuristics/blind_search_heuristic.h
@@ -10,7 +10,7 @@ protected:
     virtual int compute_heuristic(const State &ancestor_state) override;
 public:
     BlindSearchHeuristic(
-        const std::shared_ptr<AbstractTask> &transform, bool cache_estimates,
+        const std::shared_ptr<AbstractTask> &task, bool cache_estimates,
         const std::string &description, utils::Verbosity verbosity);
 };
 }

--- a/src/search/heuristics/cea_heuristic.cc
+++ b/src/search/heuristics/cea_heuristic.cc
@@ -411,10 +411,11 @@ int ContextEnhancedAdditiveHeuristic::compute_heuristic(
 }
 
 ContextEnhancedAdditiveHeuristic::ContextEnhancedAdditiveHeuristic(
-    tasks::AxiomHandlingType axioms, const shared_ptr<AbstractTask> &transform,
+    const shared_ptr<AbstractTask> &task, tasks::AxiomHandlingType axioms,
     bool cache_estimates, const string &description, utils::Verbosity verbosity)
     : Heuristic(
-          tasks::get_default_value_axioms_task_if_needed(transform, axioms),
+          // issue1208 move this transformation to task-independent level?
+          tasks::get_default_value_axioms_task_if_needed(task, axioms),
           cache_estimates, description, verbosity),
       min_action_cost(task_properties::get_min_operator_cost(task_proxy)) {
     if (log.is_at_least_normal()) {
@@ -450,10 +451,10 @@ bool ContextEnhancedAdditiveHeuristic::dead_ends_are_reliable() const {
 }
 
 class ContextEnhancedAdditiveHeuristicFeature
-    : public plugins::TypedFeature<
-          Evaluator, ContextEnhancedAdditiveHeuristic> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentEvaluator> {
 public:
-    ContextEnhancedAdditiveHeuristicFeature() : TypedFeature("cea") {
+    ContextEnhancedAdditiveHeuristicFeature() : TaskIndependentFeature("cea") {
         document_title("Context-enhanced additive heuristic");
 
         tasks::add_axioms_option_to_feature(*this);
@@ -469,10 +470,10 @@ public:
         document_property("preferred operators", "yes");
     }
 
-    virtual shared_ptr<ContextEnhancedAdditiveHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<
-            ContextEnhancedAdditiveHeuristic>(
+        return components::make_auto_task_independent_component<
+            ContextEnhancedAdditiveHeuristic, Evaluator>(
             tasks::get_axioms_arguments_from_options(opts),
             get_heuristic_arguments_from_options(opts));
     }

--- a/src/search/heuristics/cea_heuristic.h
+++ b/src/search/heuristics/cea_heuristic.h
@@ -54,10 +54,11 @@ protected:
     virtual int compute_heuristic(const State &ancestor_state) override;
 public:
     ContextEnhancedAdditiveHeuristic(
-        tasks::AxiomHandlingType axioms,
-        const std::shared_ptr<AbstractTask> &transform, bool cache_estimates,
+        const std::shared_ptr<AbstractTask> &task,
+        tasks::AxiomHandlingType axioms, bool cache_estimates,
         const std::string &description, utils::Verbosity verbosity);
-    ~ContextEnhancedAdditiveHeuristic();
+
+    virtual ~ContextEnhancedAdditiveHeuristic() override;
     virtual bool dead_ends_are_reliable() const override;
 };
 }

--- a/src/search/heuristics/cg_heuristic.cc
+++ b/src/search/heuristics/cg_heuristic.cc
@@ -17,11 +17,12 @@ using namespace domain_transition_graph;
 
 namespace cg_heuristic {
 CGHeuristic::CGHeuristic(
-    int max_cache_size, tasks::AxiomHandlingType axioms,
-    const shared_ptr<AbstractTask> &transform, bool cache_estimates,
+    const shared_ptr<AbstractTask> &task, int max_cache_size,
+    tasks::AxiomHandlingType axioms, bool cache_estimates,
     const string &description, utils::Verbosity verbosity)
     : Heuristic(
-          tasks::get_default_value_axioms_task_if_needed(transform, axioms),
+          // issue1208 move this transformation to task-independent level?
+          tasks::get_default_value_axioms_task_if_needed(task, axioms),
           cache_estimates, description, verbosity),
       helpful_transition_extraction_counter(0),
       min_action_cost(task_properties::get_min_operator_cost(task_proxy)) {
@@ -286,9 +287,9 @@ void CGHeuristic::mark_helpful_transitions(
 }
 
 class CGHeuristicFeature
-    : public plugins::TypedFeature<Evaluator, CGHeuristic> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    CGHeuristicFeature() : TypedFeature("cg") {
+    CGHeuristicFeature() : TaskIndependentFeature("cg") {
         document_title("Causal graph heuristic");
 
         add_option<int>(
@@ -308,9 +309,9 @@ public:
         document_property("preferred operators", "yes");
     }
 
-    virtual shared_ptr<CGHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<CGHeuristic>(
+        return components::make_auto_task_independent_component<CGHeuristic, Evaluator>(
             opts.get<int>("max_cache_size"),
             tasks::get_axioms_arguments_from_options(opts),
             get_heuristic_arguments_from_options(opts));

--- a/src/search/heuristics/cg_heuristic.h
+++ b/src/search/heuristics/cg_heuristic.h
@@ -41,9 +41,9 @@ class CGHeuristic : public Heuristic {
 protected:
     virtual int compute_heuristic(const State &ancestor_state) override;
 public:
-    explicit CGHeuristic(
-        int max_cache_size, tasks::AxiomHandlingType axiom_hanlding,
-        const std::shared_ptr<AbstractTask> &transform, bool cache_estimates,
+    CGHeuristic(
+        const std::shared_ptr<AbstractTask> &task, int max_cache_size, tasks::AxiomHandlingType axiom_hanlding,
+        bool cache_estimates,
         const std::string &description, utils::Verbosity verbosity);
     virtual bool dead_ends_are_reliable() const override;
 };

--- a/src/search/heuristics/ff_heuristic.cc
+++ b/src/search/heuristics/ff_heuristic.cc
@@ -11,10 +11,10 @@ using namespace std;
 namespace ff_heuristic {
 // construction and destruction
 FFHeuristic::FFHeuristic(
-    tasks::AxiomHandlingType axioms, const shared_ptr<AbstractTask> &transform,
+    const shared_ptr<AbstractTask> &task, tasks::AxiomHandlingType axioms,
     bool cache_estimates, const string &description, utils::Verbosity verbosity)
     : AdditiveHeuristic(
-          axioms, transform, cache_estimates, description, verbosity),
+         task, axioms, cache_estimates, description, verbosity),
       relaxed_plan(task_proxy.get_operators().size(), false) {
     if (log.is_at_least_normal()) {
         log << "Initializing FF heuristic..." << endl;
@@ -71,9 +71,9 @@ int FFHeuristic::compute_heuristic(const State &ancestor_state) {
 }
 
 class FFHeuristicFeature
-    : public plugins::TypedFeature<Evaluator, FFHeuristic> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    FFHeuristicFeature() : TypedFeature("ff") {
+    FFHeuristicFeature() : TaskIndependentFeature("ff") {
         document_title("FF heuristic");
 
         relaxation_heuristic::add_relaxation_heuristic_options_to_feature(
@@ -89,9 +89,9 @@ public:
         document_property("preferred operators", "yes");
     }
 
-    virtual shared_ptr<FFHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<FFHeuristic>(
+        return components::make_auto_task_independent_component<FFHeuristic, Evaluator>(
             relaxation_heuristic::
                 get_relaxation_heuristic_arguments_from_options(opts));
     }

--- a/src/search/heuristics/ff_heuristic.h
+++ b/src/search/heuristics/ff_heuristic.h
@@ -33,8 +33,8 @@ protected:
     virtual int compute_heuristic(const State &ancestor_state) override;
 public:
     FFHeuristic(
-        tasks::AxiomHandlingType axioms,
-        const std::shared_ptr<AbstractTask> &transform, bool cache_estimates,
+        const std::shared_ptr<AbstractTask> &task,
+        tasks::AxiomHandlingType axioms, bool cache_estimates,
         const std::string &description, utils::Verbosity verbosity);
 };
 }

--- a/src/search/heuristics/goal_count_heuristic.cc
+++ b/src/search/heuristics/goal_count_heuristic.cc
@@ -8,9 +8,9 @@ using namespace std;
 
 namespace goal_count_heuristic {
 GoalCountHeuristic::GoalCountHeuristic(
-    const shared_ptr<AbstractTask> &transform, bool cache_estimates,
+    const shared_ptr<AbstractTask> &task, bool cache_estimates,
     const string &description, utils::Verbosity verbosity)
-    : Heuristic(transform, cache_estimates, description, verbosity) {
+    : Heuristic(task, cache_estimates, description, verbosity) {
     if (log.is_at_least_normal()) {
         log << "Initializing goal count heuristic..." << endl;
     }
@@ -30,9 +30,9 @@ int GoalCountHeuristic::compute_heuristic(const State &ancestor_state) {
 }
 
 class GoalCountHeuristicFeature
-    : public plugins::TypedFeature<Evaluator, GoalCountHeuristic> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    GoalCountHeuristicFeature() : TypedFeature("goalcount") {
+    GoalCountHeuristicFeature() : TaskIndependentFeature("goalcount") {
         document_title("Goal count heuristic");
 
         add_heuristic_options_to_feature(*this, "goalcount");
@@ -47,9 +47,9 @@ public:
         document_property("preferred operators", "no");
     }
 
-    virtual shared_ptr<GoalCountHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<GoalCountHeuristic>(
+        return components::make_auto_task_independent_component<GoalCountHeuristic, Evaluator>(
             get_heuristic_arguments_from_options(opts));
     }
 };

--- a/src/search/heuristics/goal_count_heuristic.h
+++ b/src/search/heuristics/goal_count_heuristic.h
@@ -9,7 +9,7 @@ protected:
     virtual int compute_heuristic(const State &ancestor_state) override;
 public:
     GoalCountHeuristic(
-        const std::shared_ptr<AbstractTask> &transform, bool cache_estimates,
+        const std::shared_ptr<AbstractTask> &task, bool cache_estimates,
         const std::string &description, utils::Verbosity verbosity);
 };
 }

--- a/src/search/heuristics/hm_heuristic.cc
+++ b/src/search/heuristics/hm_heuristic.cc
@@ -12,9 +12,9 @@ using namespace std;
 
 namespace hm_heuristic {
 HMHeuristic::HMHeuristic(
-    int m, const shared_ptr<AbstractTask> &transform, bool cache_estimates,
+    const shared_ptr<AbstractTask> &task, int m, bool cache_estimates,
     const string &description, utils::Verbosity verbosity)
-    : Heuristic(transform, cache_estimates, description, verbosity),
+    : Heuristic(task, cache_estimates, description, verbosity),
       m(m),
       has_cond_effects(task_properties::has_conditional_effects(task_proxy)),
       goals(task_properties::get_fact_pairs(task_proxy.get_goals())) {
@@ -253,9 +253,9 @@ void HMHeuristic::dump_table() const {
 }
 
 class HMHeuristicFeature
-    : public plugins::TypedFeature<Evaluator, HMHeuristic> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    HMHeuristicFeature() : TypedFeature("hm") {
+    HMHeuristicFeature() : TaskIndependentFeature("hm") {
         document_title("h^m heuristic");
 
         add_option<int>(
@@ -277,9 +277,9 @@ public:
         document_property("preferred operators", "no");
     }
 
-    virtual shared_ptr<HMHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<HMHeuristic>(
+        return components::make_auto_task_independent_component<HMHeuristic, Evaluator>(
             opts.get<int>("m"), get_heuristic_arguments_from_options(opts));
     }
 };

--- a/src/search/heuristics/hm_heuristic.h
+++ b/src/search/heuristics/hm_heuristic.h
@@ -63,7 +63,7 @@ protected:
 
 public:
     HMHeuristic(
-        int m, const std::shared_ptr<AbstractTask> &transform,
+        const std::shared_ptr<AbstractTask> &task, int m,
         bool cache_estimates, const std::string &description,
         utils::Verbosity verbosity);
 

--- a/src/search/heuristics/lm_cut_heuristic.cc
+++ b/src/search/heuristics/lm_cut_heuristic.cc
@@ -14,9 +14,9 @@ using namespace std;
 
 namespace lm_cut_heuristic {
 LandmarkCutHeuristic::LandmarkCutHeuristic(
-    const shared_ptr<AbstractTask> &transform, bool cache_estimates,
+    const shared_ptr<AbstractTask> &task, bool cache_estimates,
     const string &description, utils::Verbosity verbosity)
-    : Heuristic(transform, cache_estimates, description, verbosity),
+    : Heuristic(task, cache_estimates, description, verbosity),
       landmark_generator(make_unique<LandmarkCutLandmarks>(task_proxy)) {
     if (log.is_at_least_normal()) {
         log << "Initializing landmark cut heuristic..." << endl;
@@ -36,9 +36,9 @@ int LandmarkCutHeuristic::compute_heuristic(const State &ancestor_state) {
 }
 
 class LandmarkCutHeuristicFeature
-    : public plugins::TypedFeature<Evaluator, LandmarkCutHeuristic> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    LandmarkCutHeuristicFeature() : TypedFeature("lmcut") {
+    LandmarkCutHeuristicFeature() : TaskIndependentFeature("lmcut") {
         document_title("Landmark-cut heuristic");
 
         add_heuristic_options_to_feature(*this, "lmcut");
@@ -53,9 +53,9 @@ public:
         document_property("preferred operators", "no");
     }
 
-    virtual shared_ptr<LandmarkCutHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<LandmarkCutHeuristic>(
+        return components::make_auto_task_independent_component<LandmarkCutHeuristic, Evaluator>(
             get_heuristic_arguments_from_options(opts));
     }
 };

--- a/src/search/heuristics/lm_cut_heuristic.h
+++ b/src/search/heuristics/lm_cut_heuristic.h
@@ -18,7 +18,7 @@ class LandmarkCutHeuristic : public Heuristic {
     virtual int compute_heuristic(const State &ancestor_state) override;
 public:
     LandmarkCutHeuristic(
-        const std::shared_ptr<AbstractTask> &transform, bool cache_estimates,
+        const std::shared_ptr<AbstractTask> &task, bool cache_estimates,
         const std::string &description, utils::Verbosity verbosity);
 };
 }

--- a/src/search/heuristics/max_heuristic.cc
+++ b/src/search/heuristics/max_heuristic.cc
@@ -23,10 +23,10 @@ namespace max_heuristic {
 
 // construction and destruction
 HSPMaxHeuristic::HSPMaxHeuristic(
-    tasks::AxiomHandlingType axioms, const shared_ptr<AbstractTask> &transform,
+    const shared_ptr<AbstractTask> &task, tasks::AxiomHandlingType axioms,
     bool cache_estimates, const string &description, utils::Verbosity verbosity)
     : RelaxationHeuristic(
-          axioms, transform, cache_estimates, description, verbosity) {
+          task, axioms, cache_estimates, description, verbosity) {
     if (log.is_at_least_normal()) {
         log << "Initializing HSP max heuristic..." << endl;
     }
@@ -102,9 +102,9 @@ int HSPMaxHeuristic::compute_heuristic(const State &ancestor_state) {
 }
 
 class HSPMaxHeuristicFeature
-    : public plugins::TypedFeature<Evaluator, HSPMaxHeuristic> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    HSPMaxHeuristicFeature() : TypedFeature("hmax") {
+    HSPMaxHeuristicFeature() : TaskIndependentFeature("hmax") {
         document_title("Max heuristic");
 
         relaxation_heuristic::add_relaxation_heuristic_options_to_feature(
@@ -120,9 +120,9 @@ public:
         document_property("preferred operators", "no");
     }
 
-    virtual shared_ptr<HSPMaxHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<HSPMaxHeuristic>(
+        return components::make_auto_task_independent_component<HSPMaxHeuristic, Evaluator>(
             relaxation_heuristic::
                 get_relaxation_heuristic_arguments_from_options(opts));
     }

--- a/src/search/heuristics/max_heuristic.h
+++ b/src/search/heuristics/max_heuristic.h
@@ -34,8 +34,8 @@ protected:
     virtual int compute_heuristic(const State &ancestor_state) override;
 public:
     HSPMaxHeuristic(
-        tasks::AxiomHandlingType axioms,
-        const std::shared_ptr<AbstractTask> &transform, bool cache_estimates,
+        const std::shared_ptr<AbstractTask> &task,
+        tasks::AxiomHandlingType axioms, bool cache_estimates,
         const std::string &description, utils::Verbosity verbosity);
 };
 }

--- a/src/search/heuristics/relaxation_heuristic.cc
+++ b/src/search/heuristics/relaxation_heuristic.cc
@@ -40,7 +40,7 @@ void add_relaxation_heuristic_options_to_feature(
 }
 
 tuple<
-    tasks::AxiomHandlingType, shared_ptr<AbstractTask>, bool, string,
+    tasks::AxiomHandlingType, bool, string,
     utils::Verbosity>
 get_relaxation_heuristic_arguments_from_options(const plugins::Options &opts) {
     return tuple_cat(
@@ -50,10 +50,11 @@ get_relaxation_heuristic_arguments_from_options(const plugins::Options &opts) {
 
 // construction and destruction
 RelaxationHeuristic::RelaxationHeuristic(
-    tasks::AxiomHandlingType axioms, const shared_ptr<AbstractTask> &transform,
+    const shared_ptr<AbstractTask> &task, tasks::AxiomHandlingType axioms,
     bool cache_estimates, const string &description, utils::Verbosity verbosity)
     : Heuristic(
-          tasks::get_default_value_axioms_task_if_needed(transform, axioms),
+          // issue1208 move this transformation to task-independent level?
+          tasks::get_default_value_axioms_task_if_needed(task, axioms),
           cache_estimates, description, verbosity) {
     // Build propositions.
     propositions.resize(task_properties::get_num_facts(task_proxy));

--- a/src/search/heuristics/relaxation_heuristic.h
+++ b/src/search/heuristics/relaxation_heuristic.h
@@ -112,8 +112,8 @@ protected:
     Proposition *get_proposition(const FactProxy &fact);
 public:
     RelaxationHeuristic(
-        tasks::AxiomHandlingType axioms,
-        const std::shared_ptr<AbstractTask> &transform, bool cache_estimates,
+        const std::shared_ptr<AbstractTask> &task,
+        tasks::AxiomHandlingType axioms, bool cache_estimates,
         const std::string &description, utils::Verbosity verbosity);
 
     virtual bool dead_ends_are_reliable() const override;
@@ -122,7 +122,7 @@ public:
 extern void add_relaxation_heuristic_options_to_feature(
     plugins::Feature &feature, const std::string &description);
 extern std::tuple<
-    tasks::AxiomHandlingType, std::shared_ptr<AbstractTask>, bool, std::string,
+    tasks::AxiomHandlingType, bool, std::string,
     utils::Verbosity>
 get_relaxation_heuristic_arguments_from_options(const plugins::Options &opts);
 }

--- a/src/search/landmarks/landmark_cost_partitioning_heuristic.cc
+++ b/src/search/landmarks/landmark_cost_partitioning_heuristic.cc
@@ -16,13 +16,13 @@ using namespace std;
 
 namespace landmarks {
 LandmarkCostPartitioningHeuristic::LandmarkCostPartitioningHeuristic(
+    const shared_ptr<AbstractTask> &task,
     const shared_ptr<LandmarkFactory> &lm_factory, bool pref, bool prog_goal,
-    bool prog_gn, bool prog_r, const shared_ptr<AbstractTask> &transform,
+    bool prog_gn, bool prog_r,
     bool cache_estimates, const string &description, utils::Verbosity verbosity,
     CostPartitioningMethod cost_partitioning, bool alm,
     lp::LPSolverType lpsolver)
-    : LandmarkHeuristic(
-          pref, transform, cache_estimates, description, verbosity) {
+    : LandmarkHeuristic(task, pref, cache_estimates, description, verbosity) {
     if (log.is_at_least_normal()) {
         log << "Initializing landmark cost partitioning heuristic..." << endl;
     }
@@ -83,11 +83,10 @@ bool LandmarkCostPartitioningHeuristic::dead_ends_are_reliable() const {
 }
 
 class LandmarkCostPartitioningHeuristicFeature
-    : public plugins::TypedFeature<
-          Evaluator, LandmarkCostPartitioningHeuristic> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
     LandmarkCostPartitioningHeuristicFeature()
-        : TypedFeature("landmark_cost_partitioning") {
+        : TaskIndependentFeature("landmark_cost_partitioning") {
         document_title("Landmark cost partitioning heuristic");
         /*
           We usually have the options of base classes behind the options
@@ -164,10 +163,10 @@ public:
         document_property("safe", "yes");
     }
 
-    virtual shared_ptr<LandmarkCostPartitioningHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<
-            LandmarkCostPartitioningHeuristic>(
+        return components::make_auto_task_independent_component<
+            LandmarkCostPartitioningHeuristic, Evaluator>(
             get_landmark_heuristic_arguments_from_options(opts),
             opts.get<CostPartitioningMethod>("cost_partitioning"),
             opts.get<bool>("alm"),

--- a/src/search/landmarks/landmark_cost_partitioning_heuristic.h
+++ b/src/search/landmarks/landmark_cost_partitioning_heuristic.h
@@ -25,9 +25,10 @@ class LandmarkCostPartitioningHeuristic : public LandmarkHeuristic {
     int get_heuristic_value(const State &ancestor_state) override;
 public:
     LandmarkCostPartitioningHeuristic(
+        const std::shared_ptr<AbstractTask> &task,
         const std::shared_ptr<LandmarkFactory> &lm_factory, bool pref,
         bool prog_goal, bool prog_gn, bool prog_r,
-        const std::shared_ptr<AbstractTask> &transform, bool cache_estimates,
+        bool cache_estimates,
         const std::string &description, utils::Verbosity verbosity,
         CostPartitioningMethod cost_partitioning, bool alm,
         lp::LPSolverType lpsolver);

--- a/src/search/landmarks/landmark_factory.cc
+++ b/src/search/landmarks/landmark_factory.cc
@@ -16,8 +16,8 @@
 using namespace std;
 
 namespace landmarks {
-LandmarkFactory::LandmarkFactory(utils::Verbosity verbosity)
-    : log(get_log_for_verbosity(verbosity)), landmark_graph(nullptr) {
+LandmarkFactory::LandmarkFactory(const shared_ptr<AbstractTask> &task, utils::Verbosity verbosity)
+    : components::TaskSpecificComponent(task),  log(get_log_for_verbosity(verbosity)), landmark_graph(nullptr) {
 }
 
 void LandmarkFactory::resize_operators_providing_effect(
@@ -156,6 +156,8 @@ void LandmarkFactory::log_landmark_graph_info(
   function will also get access to a TaskProxy. Then we need to ensure that the
   TaskProxy used by the Exploration object is the same as the TaskProxy object
   passed to this function.
+
+  issue1208: update comment above after removing the task transformation code.
 */
 shared_ptr<LandmarkGraph> LandmarkFactory::compute_landmark_graph(
     const shared_ptr<AbstractTask> &task) {
@@ -200,7 +202,7 @@ bool get_use_orders_arguments_from_options(const plugins::Options &opts) {
 }
 
 static class LandmarkFactoryCategoryPlugin
-    : public plugins::TypedCategoryPlugin<LandmarkFactory> {
+    : public plugins::TypedCategoryPlugin<TaskIndependentLandmarkFactory> {
 public:
     LandmarkFactoryCategoryPlugin() : TypedCategoryPlugin("LandmarkFactory") {
         document_synopsis(

--- a/src/search/landmarks/landmark_factory.h
+++ b/src/search/landmarks/landmark_factory.h
@@ -3,6 +3,8 @@
 
 #include "landmark_graph.h"
 
+#include "../component.h"
+
 #include "../utils/logging.h"
 
 #include <vector>
@@ -15,7 +17,7 @@ class Feature;
 }
 
 namespace landmarks {
-class LandmarkFactory {
+class LandmarkFactory : public components::TaskSpecificComponent {
     AbstractTask *landmark_graph_task;
     std::vector<std::vector<std::vector<int>>> operators_providing_effect;
 
@@ -38,7 +40,7 @@ protected:
     std::shared_ptr<LandmarkGraph> landmark_graph;
     bool achievers_calculated = false;
 
-    explicit LandmarkFactory(utils::Verbosity verbosity);
+    LandmarkFactory(const std::shared_ptr<AbstractTask> &task, utils::Verbosity verbosity);
 
     void add_or_replace_ordering_if_stronger(
         LandmarkNode &from, LandmarkNode &to, OrderingType type) const;
@@ -51,7 +53,6 @@ protected:
     }
 
 public:
-    virtual ~LandmarkFactory() = default;
     LandmarkFactory(const LandmarkFactory &) = delete;
 
     std::shared_ptr<LandmarkGraph> compute_landmark_graph(
@@ -63,6 +64,8 @@ public:
         return achievers_calculated;
     }
 };
+using TaskIndependentLandmarkFactory =
+    components::TaskIndependentComponent<LandmarkFactory>;
 
 extern void add_landmark_factory_options_to_feature(plugins::Feature &feature);
 extern std::tuple<utils::Verbosity> get_landmark_factory_arguments_from_options(

--- a/src/search/landmarks/landmark_factory_hm.cc
+++ b/src/search/landmarks/landmark_factory_hm.cc
@@ -576,9 +576,10 @@ void LandmarkFactoryHM::build_pm_operators(const TaskProxy &task_proxy) {
 }
 
 LandmarkFactoryHM::LandmarkFactoryHM(
+    const shared_ptr<AbstractTask> &task,
     int m, bool conjunctive_landmarks, bool use_orders,
     utils::Verbosity verbosity)
-    : LandmarkFactory(verbosity),
+    : LandmarkFactory(task, verbosity),
       m(m),
       conjunctive_landmarks(conjunctive_landmarks),
       use_orders(use_orders) {
@@ -1043,9 +1044,9 @@ bool LandmarkFactoryHM::supports_conditional_effects() const {
 }
 
 class LandmarkFactoryHMFeature
-    : public plugins::TypedFeature<LandmarkFactory, LandmarkFactoryHM> {
+    : public plugins::TaskIndependentFeature<TaskIndependentLandmarkFactory> {
 public:
-    LandmarkFactoryHMFeature() : TypedFeature("lm_hm") {
+    LandmarkFactoryHMFeature() : TaskIndependentFeature("lm_hm") {
         // document_group("");
         document_title("h^m landmarks");
         document_synopsis(
@@ -1070,9 +1071,9 @@ public:
             "conditional_effects", "ignored, i.e. not supported");
     }
 
-    virtual shared_ptr<LandmarkFactoryHM> create_component(
+    virtual shared_ptr<TaskIndependentLandmarkFactory> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<LandmarkFactoryHM>(
+        return components::make_auto_task_independent_component<LandmarkFactoryHM, LandmarkFactory>(
             opts.get<int>("m"), opts.get<bool>("conjunctive_landmarks"),
             get_use_orders_arguments_from_options(opts),
             get_landmark_factory_arguments_from_options(opts));

--- a/src/search/landmarks/landmark_factory_hm.h
+++ b/src/search/landmarks/landmark_factory_hm.h
@@ -233,6 +233,7 @@ class LandmarkFactoryHM : public LandmarkFactory {
 
 public:
     LandmarkFactoryHM(
+        const std::shared_ptr<AbstractTask> &task,
         int m, bool conjunctive_landmarks, bool use_orders,
         utils::Verbosity verbosity);
 

--- a/src/search/landmarks/landmark_factory_merged.cc
+++ b/src/search/landmarks/landmark_factory_merged.cc
@@ -16,9 +16,10 @@ namespace landmarks {
 class LandmarkNode;
 
 LandmarkFactoryMerged::LandmarkFactoryMerged(
+    const shared_ptr<AbstractTask> &task,
     const vector<shared_ptr<LandmarkFactory>> &lm_factories,
     utils::Verbosity verbosity)
-    : LandmarkFactory(verbosity), landmark_factories(lm_factories) {
+    : LandmarkFactory(task, verbosity), landmark_factories(lm_factories) {
     utils::verify_list_not_empty(lm_factories, "lm_factories");
 }
 
@@ -172,14 +173,14 @@ bool LandmarkFactoryMerged::supports_conditional_effects() const {
 }
 
 class LandmarkFactoryMergedFeature
-    : public plugins::TypedFeature<LandmarkFactory, LandmarkFactoryMerged> {
+    : public plugins::TaskIndependentFeature<TaskIndependentLandmarkFactory> {
 public:
-    LandmarkFactoryMergedFeature() : TypedFeature("lm_merged") {
+    LandmarkFactoryMergedFeature() : TaskIndependentFeature("lm_merged") {
         document_title("Merged landmarks");
         document_synopsis(
             "Merges the landmarks and orderings from the parameter landmarks");
 
-        add_list_option<shared_ptr<LandmarkFactory>>("lm_factories");
+        add_list_option<shared_ptr<TaskIndependentLandmarkFactory>>("lm_factories");
         add_landmark_factory_options_to_feature(*this);
 
         document_note(
@@ -194,10 +195,10 @@ public:
             "conditional_effects", "supported if all components support them");
     }
 
-    virtual shared_ptr<LandmarkFactoryMerged> create_component(
+    virtual shared_ptr<TaskIndependentLandmarkFactory> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<LandmarkFactoryMerged>(
-            opts.get_list<shared_ptr<LandmarkFactory>>("lm_factories"),
+        return components::make_auto_task_independent_component<LandmarkFactoryMerged, LandmarkFactory>(
+            opts.get_list<shared_ptr<TaskIndependentLandmarkFactory>>("lm_factories"),
             get_landmark_factory_arguments_from_options(opts));
     }
 };

--- a/src/search/landmarks/landmark_factory_merged.h
+++ b/src/search/landmarks/landmark_factory_merged.h
@@ -26,6 +26,7 @@ class LandmarkFactoryMerged : public LandmarkFactory {
     LandmarkNode *get_matching_landmark(const Landmark &landmark) const;
 public:
     LandmarkFactoryMerged(
+        const std::shared_ptr<AbstractTask> &task,
         const std::vector<std::shared_ptr<LandmarkFactory>> &lm_factories,
         utils::Verbosity verbosity);
 

--- a/src/search/landmarks/landmark_factory_reasonable_orders_hps.cc
+++ b/src/search/landmarks/landmark_factory_reasonable_orders_hps.cc
@@ -13,8 +13,9 @@
 using namespace std;
 namespace landmarks {
 LandmarkFactoryReasonableOrdersHPS::LandmarkFactoryReasonableOrdersHPS(
+    const shared_ptr<AbstractTask> &task,
     const shared_ptr<LandmarkFactory> &lm_factory, utils::Verbosity verbosity)
-    : LandmarkFactory(verbosity), landmark_factory(lm_factory) {
+    : LandmarkFactory(task, verbosity), landmark_factory(lm_factory) {
 }
 
 void LandmarkFactoryReasonableOrdersHPS::generate_landmarks(
@@ -378,11 +379,11 @@ bool LandmarkFactoryReasonableOrdersHPS::supports_conditional_effects() const {
 }
 
 class LandmarkFactoryReasonableOrdersHPSFeature
-    : public plugins::TypedFeature<
-          LandmarkFactory, LandmarkFactoryReasonableOrdersHPS> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentLandmarkFactory> {
 public:
     LandmarkFactoryReasonableOrdersHPSFeature()
-        : TypedFeature("lm_reasonable_orders_hps") {
+        : TaskIndependentFeature("lm_reasonable_orders_hps") {
         document_title("HPS orders");
         document_synopsis(
             "Adds reasonable orders described in the following paper" +
@@ -405,7 +406,7 @@ public:
             "effect on the performance of LAMA (Büchner et al., 2023) and "
             "decided to remove them in issue1089.");
 
-        add_option<shared_ptr<LandmarkFactory>>("lm_factory");
+        add_option<shared_ptr<TaskIndependentLandmarkFactory>>("lm_factory");
         add_landmark_factory_options_to_feature(*this);
 
         // TODO: correct?
@@ -413,11 +414,11 @@ public:
             "conditional_effects", "supported if subcomponent supports them");
     }
 
-    virtual shared_ptr<LandmarkFactoryReasonableOrdersHPS> create_component(
+    virtual shared_ptr<TaskIndependentLandmarkFactory> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<
-            LandmarkFactoryReasonableOrdersHPS>(
-            opts.get<shared_ptr<LandmarkFactory>>("lm_factory"),
+        return components::make_auto_task_independent_component<
+            LandmarkFactoryReasonableOrdersHPS, LandmarkFactory>(
+            opts.get<shared_ptr<TaskIndependentLandmarkFactory>>("lm_factory"),
             get_landmark_factory_arguments_from_options(opts));
     }
 };

--- a/src/search/landmarks/landmark_factory_reasonable_orders_hps.h
+++ b/src/search/landmarks/landmark_factory_reasonable_orders_hps.h
@@ -30,6 +30,7 @@ class LandmarkFactoryReasonableOrdersHPS : public LandmarkFactory {
         const Landmark &landmark_b) const;
 public:
     LandmarkFactoryReasonableOrdersHPS(
+        const std::shared_ptr<AbstractTask> &task,
         const std::shared_ptr<LandmarkFactory> &lm_factory,
         utils::Verbosity verbosity);
 

--- a/src/search/landmarks/landmark_factory_relaxation.cc
+++ b/src/search/landmarks/landmark_factory_relaxation.cc
@@ -8,8 +8,9 @@
 using namespace std;
 
 namespace landmarks {
-LandmarkFactoryRelaxation::LandmarkFactoryRelaxation(utils::Verbosity verbosity)
-    : LandmarkFactory(verbosity) {
+LandmarkFactoryRelaxation::LandmarkFactoryRelaxation(
+    const shared_ptr<AbstractTask> &task, utils::Verbosity verbosity)
+    : LandmarkFactory(task, verbosity) {
 }
 
 void LandmarkFactoryRelaxation::generate_landmarks(

--- a/src/search/landmarks/landmark_factory_relaxation.h
+++ b/src/search/landmarks/landmark_factory_relaxation.h
@@ -19,7 +19,7 @@ class LandmarkFactoryRelaxation : public LandmarkFactory {
     void calc_achievers(const TaskProxy &task_proxy, Exploration &exploration);
 
 protected:
-    explicit LandmarkFactoryRelaxation(utils::Verbosity verbosity);
+    LandmarkFactoryRelaxation(const std::shared_ptr<AbstractTask> &task, utils::Verbosity verbosity);
 };
 }
 

--- a/src/search/landmarks/landmark_factory_rpg_exhaust.cc
+++ b/src/search/landmarks/landmark_factory_rpg_exhaust.cc
@@ -21,8 +21,9 @@ namespace landmarks {
 */
 
 LandmarkFactoryRpgExhaust::LandmarkFactoryRpgExhaust(
+    const shared_ptr<AbstractTask> &task,
     bool use_unary_relaxation, utils::Verbosity verbosity)
-    : LandmarkFactoryRelaxation(verbosity),
+    : LandmarkFactoryRelaxation(task, verbosity),
       use_unary_relaxation(use_unary_relaxation) {
 }
 
@@ -82,9 +83,9 @@ bool LandmarkFactoryRpgExhaust::supports_conditional_effects() const {
 }
 
 class LandmarkFactoryRpgExhaustFeature
-    : public plugins::TypedFeature<LandmarkFactory, LandmarkFactoryRpgExhaust> {
+    : public plugins::TaskIndependentFeature<TaskIndependentLandmarkFactory> {
 public:
-    LandmarkFactoryRpgExhaustFeature() : TypedFeature("lm_exhaust") {
+    LandmarkFactoryRpgExhaustFeature() : TaskIndependentFeature("lm_exhaust") {
         document_title("Exhaustive landmarks");
         document_synopsis(
             "Exhaustively checks for each atom if it is a landmark."
@@ -106,9 +107,9 @@ public:
             "conditional_effects", "ignored, i.e. not supported");
     }
 
-    virtual shared_ptr<LandmarkFactoryRpgExhaust> create_component(
+    virtual shared_ptr<TaskIndependentLandmarkFactory> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<LandmarkFactoryRpgExhaust>(
+        return components::make_auto_task_independent_component<LandmarkFactoryRpgExhaust, LandmarkFactory>(
             opts.get<bool>("use_unary_relaxation"),
             get_landmark_factory_arguments_from_options(opts));
     }

--- a/src/search/landmarks/landmark_factory_rpg_exhaust.h
+++ b/src/search/landmarks/landmark_factory_rpg_exhaust.h
@@ -14,7 +14,8 @@ class LandmarkFactoryRpgExhaust : public LandmarkFactoryRelaxation {
         Exploration &exploration) override;
 
 public:
-    explicit LandmarkFactoryRpgExhaust(
+    LandmarkFactoryRpgExhaust(
+        const std::shared_ptr<AbstractTask> &task,
         bool use_unary_relaxation, utils::Verbosity verbosity);
 
     virtual bool supports_conditional_effects() const override;

--- a/src/search/landmarks/landmark_factory_rpg_sasp.cc
+++ b/src/search/landmarks/landmark_factory_rpg_sasp.cc
@@ -21,8 +21,9 @@ using utils::ExitCode;
 
 namespace landmarks {
 LandmarkFactoryRpgSasp::LandmarkFactoryRpgSasp(
+    const shared_ptr<AbstractTask> &task,
     bool disjunctive_landmarks, bool use_orders, utils::Verbosity verbosity)
-    : LandmarkFactoryRelaxation(verbosity),
+    : LandmarkFactoryRelaxation(task, verbosity),
       disjunctive_landmarks(disjunctive_landmarks),
       use_orders(use_orders) {
 }
@@ -751,9 +752,9 @@ bool LandmarkFactoryRpgSasp::supports_conditional_effects() const {
 }
 
 class LandmarkFactoryRpgSaspFeature
-    : public plugins::TypedFeature<LandmarkFactory, LandmarkFactoryRpgSasp> {
+    : public plugins::TaskIndependentFeature<TaskIndependentLandmarkFactory> {
 public:
-    LandmarkFactoryRpgSaspFeature() : TypedFeature("lm_rhw") {
+    LandmarkFactoryRpgSaspFeature() : TaskIndependentFeature("lm_rhw") {
         document_title("RHW landmarks");
         document_synopsis("The landmark generation method introduced by "
                           "Richter, Helmert and Westphal (AAAI 2008).");
@@ -765,9 +766,9 @@ public:
         document_language_support("conditional_effects", "supported");
     }
 
-    virtual shared_ptr<LandmarkFactoryRpgSasp> create_component(
+    virtual shared_ptr<TaskIndependentLandmarkFactory> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<LandmarkFactoryRpgSasp>(
+        return components::make_auto_task_independent_component<LandmarkFactoryRpgSasp, LandmarkFactory>(
             opts.get<bool>("disjunctive_landmarks"),
             get_use_orders_arguments_from_options(opts),
             get_landmark_factory_arguments_from_options(opts));

--- a/src/search/landmarks/landmark_factory_rpg_sasp.h
+++ b/src/search/landmarks/landmark_factory_rpg_sasp.h
@@ -84,6 +84,7 @@ class LandmarkFactoryRpgSasp : public LandmarkFactoryRelaxation {
     void discard_disjunctive_landmarks() const;
 public:
     LandmarkFactoryRpgSasp(
+        const std::shared_ptr<AbstractTask> &task,
         bool disjunctive_landmarks, bool use_orders,
         utils::Verbosity verbosity);
 

--- a/src/search/landmarks/landmark_factory_zhu_givan.cc
+++ b/src/search/landmarks/landmark_factory_zhu_givan.cc
@@ -16,8 +16,9 @@ using namespace std;
 
 namespace landmarks {
 LandmarkFactoryZhuGivan::LandmarkFactoryZhuGivan(
+    const shared_ptr<AbstractTask> &task,
     bool use_orders, utils::Verbosity verbosity)
-    : LandmarkFactoryRelaxation(verbosity), use_orders(use_orders) {
+    : LandmarkFactoryRelaxation(task, verbosity), use_orders(use_orders) {
 }
 
 void LandmarkFactoryZhuGivan::generate_relaxed_landmarks(
@@ -313,9 +314,9 @@ bool LandmarkFactoryZhuGivan::supports_conditional_effects() const {
 }
 
 class LandmarkFactoryZhuGivanFeature
-    : public plugins::TypedFeature<LandmarkFactory, LandmarkFactoryZhuGivan> {
+    : public plugins::TaskIndependentFeature<TaskIndependentLandmarkFactory> {
 public:
-    LandmarkFactoryZhuGivanFeature() : TypedFeature("lm_zg") {
+    LandmarkFactoryZhuGivanFeature() : TaskIndependentFeature("lm_zg") {
         document_title("Zhu/Givan landmarks");
         document_synopsis("The landmark generation method introduced by "
                           "Zhu & Givan (ICAPS 2003 Doctoral Consortium).");
@@ -328,9 +329,9 @@ public:
             "We think they are supported, but this is not 100% sure.");
     }
 
-    virtual shared_ptr<LandmarkFactoryZhuGivan> create_component(
+    virtual shared_ptr<TaskIndependentLandmarkFactory> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<LandmarkFactoryZhuGivan>(
+        return components::make_auto_task_independent_component<LandmarkFactoryZhuGivan, LandmarkFactory>(
             get_use_orders_arguments_from_options(opts),
             get_landmark_factory_arguments_from_options(opts));
     }

--- a/src/search/landmarks/landmark_factory_zhu_givan.h
+++ b/src/search/landmarks/landmark_factory_zhu_givan.h
@@ -81,7 +81,7 @@ class LandmarkFactoryZhuGivan : public LandmarkFactoryRelaxation {
         Exploration &exploration) override;
 
 public:
-    LandmarkFactoryZhuGivan(bool use_orders, utils::Verbosity verbosity);
+    LandmarkFactoryZhuGivan(const std::shared_ptr<AbstractTask> &task, bool use_orders, utils::Verbosity verbosity);
 
     virtual bool supports_conditional_effects() const override;
 };

--- a/src/search/landmarks/landmark_heuristic.cc
+++ b/src/search/landmarks/landmark_heuristic.cc
@@ -14,9 +14,9 @@ using namespace std;
 
 namespace landmarks {
 LandmarkHeuristic::LandmarkHeuristic(
-    bool use_preferred_operators, const shared_ptr<AbstractTask> &transform,
+    const shared_ptr<AbstractTask> &task, bool use_preferred_operators,
     bool cache_estimates, const string &description, utils::Verbosity verbosity)
-    : Heuristic(transform, cache_estimates, description, verbosity),
+    : Heuristic(task, cache_estimates, description, verbosity),
       initial_landmark_graph_has_cycle_of_natural_orderings(false),
       use_preferred_operators(use_preferred_operators),
       successor_generator(nullptr) {
@@ -68,6 +68,9 @@ void LandmarkHeuristic::initialize(
       transforms costs and/or adds negated axioms. However, there is currently
       no good way to do this, so we use this incomplete, slightly less safe
       test.
+
+      issue1208 update the comment after removing the task transformation code.
+      The check can hopefully just be removed.
     */
     if (task != tasks::g_root_task &&
         dynamic_cast<tasks::CostAdaptedTask *>(task.get()) == nullptr &&
@@ -240,7 +243,7 @@ void add_landmark_heuristic_options_to_feature(
             "Automated Planning and Scheduling (ICAPS 2023)",
             "70-79", "AAAI Press", "2023"));
 
-    feature.add_option<shared_ptr<LandmarkFactory>>(
+    feature.add_option<shared_ptr<TaskIndependentLandmarkFactory>>(
         "lm_factory", "the set of landmarks to use for this heuristic. "
                       "The set of landmarks can be specified here, "
                       "or predefined (see LandmarkFactory).");
@@ -260,12 +263,12 @@ void add_landmark_heuristic_options_to_feature(
 }
 
 tuple<
-    shared_ptr<LandmarkFactory>, bool, bool, bool, bool,
-    shared_ptr<AbstractTask>, bool, string, utils::Verbosity>
+    shared_ptr<TaskIndependentLandmarkFactory>, bool, bool, bool, bool, bool,
+    string, utils::Verbosity>
 get_landmark_heuristic_arguments_from_options(const plugins::Options &opts) {
     return tuple_cat(
         make_tuple(
-            opts.get<shared_ptr<LandmarkFactory>>("lm_factory"),
+            opts.get<shared_ptr<TaskIndependentLandmarkFactory>>("lm_factory"),
             opts.get<bool>("pref"), opts.get<bool>("prog_goal"),
             opts.get<bool>("prog_gn"), opts.get<bool>("prog_r")),
         get_heuristic_arguments_from_options(opts));

--- a/src/search/landmarks/landmark_heuristic.h
+++ b/src/search/landmarks/landmark_heuristic.h
@@ -1,6 +1,8 @@
 #ifndef LANDMARKS_LANDMARK_HEURISTIC_H
 #define LANDMARKS_LANDMARK_HEURISTIC_H
 
+#include "landmark_factory.h"
+
 #include "../heuristic.h"
 
 #include "../tasks/default_value_axioms_task.h"
@@ -13,9 +15,6 @@ class SuccessorGenerator;
 }
 
 namespace landmarks {
-class LandmarkFactory;
-class LandmarkGraph;
-class LandmarkNode;
 class LandmarkStatusManager;
 
 class LandmarkHeuristic : public Heuristic {
@@ -48,8 +47,9 @@ protected:
     virtual int compute_heuristic(const State &ancestor_state) override;
 public:
     LandmarkHeuristic(
+        const std::shared_ptr<AbstractTask> &task,
         bool use_preferred_operators,
-        const std::shared_ptr<AbstractTask> &transform, bool cache_estimates,
+        bool cache_estimates,
         const std::string &description, utils::Verbosity verbosity);
 
     virtual void get_path_dependent_evaluators(
@@ -66,8 +66,8 @@ public:
 extern void add_landmark_heuristic_options_to_feature(
     plugins::Feature &feature, const std::string &description);
 extern std::tuple<
-    std::shared_ptr<LandmarkFactory>, bool, bool, bool, bool,
-    std::shared_ptr<AbstractTask>, bool, std::string, utils::Verbosity>
+    std::shared_ptr<TaskIndependentLandmarkFactory>, bool, bool, bool, bool,
+    bool, std::string, utils::Verbosity>
 get_landmark_heuristic_arguments_from_options(const plugins::Options &opts);
 }
 

--- a/src/search/landmarks/landmark_sum_heuristic.cc
+++ b/src/search/landmarks/landmark_sum_heuristic.cc
@@ -31,13 +31,15 @@ static bool are_dead_ends_reliable(
 }
 
 LandmarkSumHeuristic::LandmarkSumHeuristic(
+    const shared_ptr<AbstractTask> &task,
     const shared_ptr<LandmarkFactory> &lm_factory, bool pref, bool prog_goal,
-    bool prog_gn, bool prog_r, const shared_ptr<AbstractTask> &transform,
+    bool prog_gn, bool prog_r,
     bool cache_estimates, const string &description, utils::Verbosity verbosity,
     tasks::AxiomHandlingType axioms)
     : LandmarkHeuristic(
+          // issue1208 move this transformation to task-independent level?
+          tasks::get_default_value_axioms_task_if_needed(task, axioms),
           pref,
-          tasks::get_default_value_axioms_task_if_needed(transform, axioms),
           cache_estimates, description, verbosity),
       dead_ends_reliable(are_dead_ends_reliable(lm_factory, task_proxy)) {
     if (log.is_at_least_normal()) {
@@ -108,9 +110,9 @@ bool LandmarkSumHeuristic::dead_ends_are_reliable() const {
 }
 
 class LandmarkSumHeuristicFeature
-    : public plugins::TypedFeature<Evaluator, LandmarkSumHeuristic> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    LandmarkSumHeuristicFeature() : TypedFeature("landmark_sum") {
+    LandmarkSumHeuristicFeature() : TaskIndependentFeature("landmark_sum") {
         document_title("Landmark sum heuristic");
         /*
           We usually have the options of base classes behind the options
@@ -149,8 +151,8 @@ public:
             "achieve it. For satisficing search this can be counterproductive "
             "since it is often better to focus on distance from goal (i.e. "
             "length of the plan) rather than cost. In experiments we achieved "
-            "the best performance using the option "
-            "'transform=adapt_costs(one)' to enforce unit costs.");
+            "the best performance wrapping this heuristic in "
+            "'eval_modify_costs(..., cost_type=one)' to enforce unit costs.");
         document_note(
             "Preferred operators",
             "Computing preferred operators is *only enabled* when setting "
@@ -192,9 +194,9 @@ public:
                     "using a LandmarkFactory not supporting them");
     }
 
-    virtual shared_ptr<LandmarkSumHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<LandmarkSumHeuristic>(
+        return components::make_auto_task_independent_component<LandmarkSumHeuristic, Evaluator>(
             get_landmark_heuristic_arguments_from_options(opts),
             tasks::get_axioms_arguments_from_options(opts));
     }

--- a/src/search/landmarks/landmark_sum_heuristic.h
+++ b/src/search/landmarks/landmark_sum_heuristic.h
@@ -23,9 +23,10 @@ class LandmarkSumHeuristic : public LandmarkHeuristic {
     int get_heuristic_value(const State &ancestor_state) override;
 public:
     LandmarkSumHeuristic(
+        const std::shared_ptr<AbstractTask> &task,
         const std::shared_ptr<LandmarkFactory> &lm_factory, bool pref,
         bool prog_goal, bool prog_gn, bool prog_r,
-        const std::shared_ptr<AbstractTask> &transform, bool cache_estimates,
+        bool cache_estimates,
         const std::string &description, utils::Verbosity verbosity,
         tasks::AxiomHandlingType axioms);
 

--- a/src/search/merge_and_shrink/label_reduction.cc
+++ b/src/search/merge_and_shrink/label_reduction.cc
@@ -27,9 +27,10 @@ using utils::ExitCode;
 
 namespace merge_and_shrink {
 LabelReduction::LabelReduction(
+    const shared_ptr<AbstractTask> &task,
     bool before_shrinking, bool before_merging, LabelReductionMethod method,
     LabelReductionSystemOrder system_order, int random_seed)
-    : lr_before_shrinking(before_shrinking),
+    : components::TaskSpecificComponent(task), lr_before_shrinking(before_shrinking),
       lr_before_merging(before_merging),
       lr_method(method),
       lr_system_order(system_order),
@@ -294,9 +295,9 @@ void LabelReduction::dump_options(utils::LogProxy &log) const {
 }
 
 class LabelReductionFeature
-    : public plugins::TypedFeature<LabelReduction, LabelReduction> {
+    : public plugins::TaskIndependentFeature<TaskIndependentLabelReduction> {
 public:
-    LabelReductionFeature() : TypedFeature("exact") {
+    LabelReductionFeature() : TaskIndependentFeature("exact") {
         document_title("Exact generalized label reduction");
         document_synopsis(
             "This class implements the exact generalized label reduction "
@@ -338,9 +339,9 @@ public:
         utils::add_rng_options_to_feature(*this);
     }
 
-    virtual shared_ptr<LabelReduction> create_component(
+    virtual shared_ptr<TaskIndependentLabelReduction> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<LabelReduction>(
+        return components::make_auto_task_independent_component<LabelReduction, LabelReduction>(
             opts.get<bool>("before_shrinking"),
             opts.get<bool>("before_merging"),
             opts.get<LabelReductionMethod>("method"),
@@ -352,7 +353,7 @@ public:
 static plugins::FeaturePlugin<LabelReductionFeature> _plugin;
 
 static class LabelReductionCategoryPlugin
-    : public plugins::TypedCategoryPlugin<LabelReduction> {
+    : public plugins::TypedCategoryPlugin<TaskIndependentLabelReduction> {
 public:
     LabelReductionCategoryPlugin() : TypedCategoryPlugin("LabelReduction") {
         document_synopsis(

--- a/src/search/merge_and_shrink/label_reduction.h
+++ b/src/search/merge_and_shrink/label_reduction.h
@@ -1,6 +1,8 @@
 #ifndef MERGE_AND_SHRINK_LABEL_REDUCTION_H
 #define MERGE_AND_SHRINK_LABEL_REDUCTION_H
 
+#include "../component.h"
+
 #include <memory>
 #include <vector>
 
@@ -53,7 +55,7 @@ enum class LabelReductionSystemOrder {
     RANDOM
 };
 
-class LabelReduction {
+class LabelReduction : public components::TaskSpecificComponent {
     // Options for label reduction
     std::vector<int> transition_system_order;
     bool lr_before_shrinking;
@@ -75,6 +77,7 @@ class LabelReduction {
         int ts_index, const FactoredTransitionSystem &fts) const;
 public:
     LabelReduction(
+        const std::shared_ptr<AbstractTask> &task,
         bool before_shrinking, bool before_merging, LabelReductionMethod method,
         LabelReductionSystemOrder system_order, int random_seed);
     void initialize(const TaskProxy &task_proxy);
@@ -89,6 +92,9 @@ public:
         return lr_before_merging;
     }
 };
+
+using TaskIndependentLabelReduction =
+    components::TaskIndependentComponent<LabelReduction>;
 }
 
 #endif

--- a/src/search/merge_and_shrink/merge_and_shrink_algorithm.cc
+++ b/src/search/merge_and_shrink/merge_and_shrink_algorithm.cc
@@ -464,7 +464,7 @@ MergeAndShrinkAlgorithm::build_factored_transition_system(
 void add_merge_and_shrink_algorithm_options_to_feature(
     plugins::Feature &feature) {
     // Merge strategy option.
-    feature.add_option<shared_ptr<MergeStrategyFactory>>(
+    feature.add_option<shared_ptr<TaskIndependentMergeStrategyFactory>>(
         "merge_strategy",
         "See detailed documentation for merge strategies. "
         "We currently recommend SCC-DFP, which can be achieved using "
@@ -473,14 +473,14 @@ void add_merge_and_shrink_algorithm_options_to_feature(
         "]))}}}");
 
     // Shrink strategy option.
-    feature.add_option<shared_ptr<ShrinkStrategy>>(
+    feature.add_option<shared_ptr<TaskIndependentShrinkStrategy>>(
         "shrink_strategy",
         "See detailed documentation for shrink strategies. "
         "We currently recommend non-greedy shrink_bisimulation, which can be "
         "achieved using {{{shrink_strategy=shrink_bisimulation(greedy=false)}}}");
 
     // Label reduction option.
-    feature.add_option<shared_ptr<LabelReduction>>(
+    feature.add_option<shared_ptr<TaskIndependentLabelReduction>>(
         "label_reduction",
         "See detailed documentation for labels. There is currently only "
         "one 'option' to use label_reduction, which is {{{label_reduction=exact}}} "
@@ -512,15 +512,15 @@ void add_merge_and_shrink_algorithm_options_to_feature(
 }
 
 tuple<
-    shared_ptr<MergeStrategyFactory>, shared_ptr<ShrinkStrategy>,
-    shared_ptr<LabelReduction>, bool, bool, int, int, int, double>
+    shared_ptr<TaskIndependentMergeStrategyFactory>, shared_ptr<TaskIndependentShrinkStrategy>,
+    shared_ptr<TaskIndependentLabelReduction>, bool, bool, int, int, int, double>
 get_merge_and_shrink_algorithm_arguments_from_options(
     const plugins::Options &opts) {
     return tuple_cat(
         make_tuple(
-            opts.get<shared_ptr<MergeStrategyFactory>>("merge_strategy"),
-            opts.get<shared_ptr<ShrinkStrategy>>("shrink_strategy"),
-            opts.get<shared_ptr<LabelReduction>>("label_reduction", nullptr),
+            opts.get<shared_ptr<TaskIndependentMergeStrategyFactory>>("merge_strategy"),
+            opts.get<shared_ptr<TaskIndependentShrinkStrategy>>("shrink_strategy"),
+            opts.get<shared_ptr<TaskIndependentLabelReduction>>("label_reduction", nullptr),
             opts.get<bool>("prune_unreachable_states"),
             opts.get<bool>("prune_irrelevant_states")),
         get_transition_system_size_limit_arguments_from_options(opts),

--- a/src/search/merge_and_shrink/merge_and_shrink_algorithm.h
+++ b/src/search/merge_and_shrink/merge_and_shrink_algorithm.h
@@ -1,6 +1,10 @@
 #ifndef MERGE_AND_SHRINK_MERGE_AND_SHRINK_ALGORITHM_H
 #define MERGE_AND_SHRINK_MERGE_AND_SHRINK_ALGORITHM_H
 
+#include "label_reduction.h"
+#include "merge_strategy_factory.h"
+#include "shrink_strategy.h"
+
 #include "../utils/logging.h"
 
 #include <memory>
@@ -19,9 +23,6 @@ class CountdownTimer;
 
 namespace merge_and_shrink {
 class FactoredTransitionSystem;
-class LabelReduction;
-class MergeStrategyFactory;
-class ShrinkStrategy;
 
 class MergeAndShrinkAlgorithm {
     // TODO: when the option parser supports it, the following should become
@@ -72,8 +73,8 @@ extern std::tuple<int, int, int> handle_shrink_limit_defaults(
 extern void add_merge_and_shrink_algorithm_options_to_feature(
     plugins::Feature &feature);
 std::tuple<
-    std::shared_ptr<MergeStrategyFactory>, std::shared_ptr<ShrinkStrategy>,
-    std::shared_ptr<LabelReduction>, bool, bool, int, int, int, double>
+    std::shared_ptr<TaskIndependentMergeStrategyFactory>, std::shared_ptr<TaskIndependentShrinkStrategy>,
+    std::shared_ptr<TaskIndependentLabelReduction>, bool, bool, int, int, int, double>
 get_merge_and_shrink_algorithm_arguments_from_options(
     const plugins::Options &opts);
 extern void add_transition_system_size_limit_options_to_feature(

--- a/src/search/merge_and_shrink/merge_and_shrink_heuristic.cc
+++ b/src/search/merge_and_shrink/merge_and_shrink_heuristic.cc
@@ -21,14 +21,15 @@ using utils::ExitCode;
 
 namespace merge_and_shrink {
 MergeAndShrinkHeuristic::MergeAndShrinkHeuristic(
+    const shared_ptr<AbstractTask> &task,
     const shared_ptr<MergeStrategyFactory> &merge_strategy,
     const shared_ptr<ShrinkStrategy> &shrink_strategy,
     const shared_ptr<LabelReduction> &label_reduction,
     bool prune_unreachable_states, bool prune_irrelevant_states, int max_states,
     int max_states_before_merge, int threshold_before_merge,
-    double main_loop_max_time, const shared_ptr<AbstractTask> &transform,
+    double main_loop_max_time,
     bool cache_estimates, const string &description, utils::Verbosity verbosity)
-    : Heuristic(transform, cache_estimates, description, verbosity) {
+    : Heuristic(task, cache_estimates, description, verbosity) {
     log << "Initializing merge-and-shrink heuristic..." << endl;
     MergeAndShrinkAlgorithm algorithm(
         merge_strategy, shrink_strategy, label_reduction,
@@ -138,9 +139,9 @@ int MergeAndShrinkHeuristic::compute_heuristic(const State &ancestor_state) {
 }
 
 class MergeAndShrinkHeuristicFeature
-    : public plugins::TypedFeature<Evaluator, MergeAndShrinkHeuristic> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    MergeAndShrinkHeuristicFeature() : TypedFeature("merge_and_shrink") {
+    MergeAndShrinkHeuristicFeature() : TaskIndependentFeature("merge_and_shrink") {
         document_title("Merge-and-shrink heuristic");
         document_synopsis(
             "This heuristic implements the algorithm described in the following "
@@ -243,9 +244,9 @@ public:
         document_property("preferred operators", "no");
     }
 
-    virtual shared_ptr<MergeAndShrinkHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<MergeAndShrinkHeuristic>(
+        return components::make_auto_task_independent_component<MergeAndShrinkHeuristic, Evaluator>(
             get_merge_and_shrink_algorithm_arguments_from_options(opts),
             get_heuristic_arguments_from_options(opts));
     }

--- a/src/search/merge_and_shrink/merge_and_shrink_heuristic.h
+++ b/src/search/merge_and_shrink/merge_and_shrink_heuristic.h
@@ -26,13 +26,14 @@ protected:
     virtual int compute_heuristic(const State &ancestor_state) override;
 public:
     MergeAndShrinkHeuristic(
+        const std::shared_ptr<AbstractTask> &task,
         const std::shared_ptr<MergeStrategyFactory> &merge_strategy,
         const std::shared_ptr<ShrinkStrategy> &shrink_strategy,
         const std::shared_ptr<LabelReduction> &label_reduction,
         bool prune_unreachable_states, bool prune_irrelevant_states,
         int max_states, int max_states_before_merge, int threshold_before_merge,
         double main_loop_max_time,
-        const std::shared_ptr<AbstractTask> &transform, bool cache_estimates,
+        bool cache_estimates,
         const std::string &description, utils::Verbosity verbosity);
 };
 }

--- a/src/search/merge_and_shrink/merge_scoring_function.cc
+++ b/src/search/merge_and_shrink/merge_scoring_function.cc
@@ -8,7 +8,8 @@
 using namespace std;
 
 namespace merge_and_shrink {
-MergeScoringFunction::MergeScoringFunction() : initialized(false) {
+MergeScoringFunction::MergeScoringFunction(const shared_ptr<AbstractTask> &task)
+    : components::TaskSpecificComponent(task), initialized(false) {
 }
 
 void MergeScoringFunction::dump_options(utils::LogProxy &log) const {
@@ -20,7 +21,7 @@ void MergeScoringFunction::dump_options(utils::LogProxy &log) const {
 }
 
 static class MergeScoringFunctionCategoryPlugin
-    : public plugins::TypedCategoryPlugin<MergeScoringFunction> {
+    : public plugins::TypedCategoryPlugin<TaskIndependentMergeScoringFunction> {
 public:
     MergeScoringFunctionCategoryPlugin()
         : TypedCategoryPlugin("MergeScoringFunction") {

--- a/src/search/merge_and_shrink/merge_scoring_function.h
+++ b/src/search/merge_and_shrink/merge_scoring_function.h
@@ -1,6 +1,8 @@
 #ifndef MERGE_AND_SHRINK_MERGE_SCORING_FUNCTION_H
 #define MERGE_AND_SHRINK_MERGE_SCORING_FUNCTION_H
 
+#include "../component.h"
+
 #include <string>
 #include <vector>
 
@@ -12,15 +14,14 @@ class LogProxy;
 
 namespace merge_and_shrink {
 class FactoredTransitionSystem;
-class MergeScoringFunction {
+class MergeScoringFunction : public components::TaskSpecificComponent {
     virtual std::string name() const = 0;
     virtual void dump_function_specific_options(utils::LogProxy &) const {
     }
 protected:
     bool initialized;
 public:
-    MergeScoringFunction();
-    virtual ~MergeScoringFunction() = default;
+    explicit MergeScoringFunction(const std::shared_ptr<AbstractTask> &task);
     virtual std::vector<double> compute_scores(
         const FactoredTransitionSystem &fts,
         const std::vector<std::pair<int, int>> &merge_candidates) = 0;
@@ -34,6 +35,9 @@ public:
 
     void dump_options(utils::LogProxy &log) const;
 };
+
+using TaskIndependentMergeScoringFunction =
+    components::TaskIndependentComponent<MergeScoringFunction>;
 }
 
 #endif

--- a/src/search/merge_and_shrink/merge_scoring_function_dfp.cc
+++ b/src/search/merge_and_shrink/merge_scoring_function_dfp.cc
@@ -59,6 +59,11 @@ static vector<int> compute_label_ranks(
     return label_ranks;
 }
 
+MergeScoringFunctionDFP::MergeScoringFunctionDFP(
+    const shared_ptr<AbstractTask> &task)
+    : MergeScoringFunction(task) {
+}
+
 vector<double> MergeScoringFunctionDFP::compute_scores(
     const FactoredTransitionSystem &fts,
     const vector<pair<int, int>> &merge_candidates) {
@@ -102,10 +107,10 @@ string MergeScoringFunctionDFP::name() const {
 }
 
 class MergeScoringFunctionDFPFeature
-    : public plugins::TypedFeature<
-          MergeScoringFunction, MergeScoringFunctionDFP> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentMergeScoringFunction> {
 public:
-    MergeScoringFunctionDFPFeature() : TypedFeature("dfp") {
+    MergeScoringFunctionDFPFeature() : TaskIndependentFeature("dfp") {
         document_title("DFP scoring");
         document_synopsis(
             "This scoring function computes the 'DFP' score as described in the "
@@ -138,9 +143,9 @@ public:
             "   threshold_before_merge=1)\n}}}");
     }
 
-    virtual shared_ptr<MergeScoringFunctionDFP> create_component(
+    virtual shared_ptr<TaskIndependentMergeScoringFunction> create_component(
         const plugins::Options &) const override {
-        return make_shared<MergeScoringFunctionDFP>();
+        return components::make_auto_task_independent_component<MergeScoringFunctionDFP, MergeScoringFunction>();
     }
 };
 

--- a/src/search/merge_and_shrink/merge_scoring_function_dfp.h
+++ b/src/search/merge_and_shrink/merge_scoring_function_dfp.h
@@ -7,7 +7,7 @@ namespace merge_and_shrink {
 class MergeScoringFunctionDFP : public MergeScoringFunction {
     virtual std::string name() const override;
 public:
-    MergeScoringFunctionDFP() = default;
+    explicit MergeScoringFunctionDFP(const std::shared_ptr<AbstractTask> &task);
     virtual std::vector<double> compute_scores(
         const FactoredTransitionSystem &fts,
         const std::vector<std::pair<int, int>> &merge_candidates) override;

--- a/src/search/merge_and_shrink/merge_scoring_function_goal_relevance.cc
+++ b/src/search/merge_and_shrink/merge_scoring_function_goal_relevance.cc
@@ -9,6 +9,11 @@
 using namespace std;
 
 namespace merge_and_shrink {
+MergeScoringFunctionGoalRelevance::MergeScoringFunctionGoalRelevance(
+    const shared_ptr<AbstractTask> &task)
+    : MergeScoringFunction(task) {
+}
+
 vector<double> MergeScoringFunctionGoalRelevance::compute_scores(
     const FactoredTransitionSystem &fts,
     const vector<pair<int, int>> &merge_candidates) {
@@ -40,11 +45,11 @@ string MergeScoringFunctionGoalRelevance::name() const {
 }
 
 class MergeScoringFunctionGoalRelevanceFeature
-    : public plugins::TypedFeature<
-          MergeScoringFunction, MergeScoringFunctionGoalRelevance> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentMergeScoringFunction> {
 public:
     MergeScoringFunctionGoalRelevanceFeature()
-        : TypedFeature("goal_relevance") {
+        : TaskIndependentFeature("goal_relevance") {
         document_title("Goal relevance scoring");
         document_synopsis(
             "This scoring function assigns a merge candidate a value of 0 iff at "
@@ -53,9 +58,9 @@ public:
             "All other candidates get a score of positive infinity.");
     }
 
-    virtual shared_ptr<MergeScoringFunctionGoalRelevance> create_component(
+    virtual shared_ptr<TaskIndependentMergeScoringFunction> create_component(
         const plugins::Options &) const override {
-        return make_shared<MergeScoringFunctionGoalRelevance>();
+        return components::make_auto_task_independent_component<MergeScoringFunctionGoalRelevance, MergeScoringFunction>();
     }
 };
 

--- a/src/search/merge_and_shrink/merge_scoring_function_goal_relevance.h
+++ b/src/search/merge_and_shrink/merge_scoring_function_goal_relevance.h
@@ -7,7 +7,7 @@ namespace merge_and_shrink {
 class MergeScoringFunctionGoalRelevance : public MergeScoringFunction {
     virtual std::string name() const override;
 public:
-    MergeScoringFunctionGoalRelevance() = default;
+    explicit MergeScoringFunctionGoalRelevance(const std::shared_ptr<AbstractTask> &task);
     virtual std::vector<double> compute_scores(
         const FactoredTransitionSystem &fts,
         const std::vector<std::pair<int, int>> &merge_candidates) override;

--- a/src/search/merge_and_shrink/merge_scoring_function_miasm.cc
+++ b/src/search/merge_and_shrink/merge_scoring_function_miasm.cc
@@ -17,9 +17,10 @@ using namespace std;
 
 namespace merge_and_shrink {
 MergeScoringFunctionMIASM::MergeScoringFunctionMIASM(
+    const shared_ptr<AbstractTask> &task,
     shared_ptr<ShrinkStrategy> shrink_strategy, int max_states,
     int max_states_before_merge, int threshold_before_merge, bool use_caching)
-    : use_caching(use_caching),
+    : MergeScoringFunction(task), use_caching(use_caching),
       shrink_strategy(move(shrink_strategy)),
       max_states(max_states),
       max_states_before_merge(max_states_before_merge),
@@ -103,10 +104,10 @@ string MergeScoringFunctionMIASM::name() const {
 }
 
 class MergeScoringFunctionMIASMFeature
-    : public plugins::TypedFeature<
-          MergeScoringFunction, MergeScoringFunctionMIASM> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentMergeScoringFunction> {
 public:
-    MergeScoringFunctionMIASMFeature() : TypedFeature("sf_miasm") {
+    MergeScoringFunctionMIASMFeature() : TaskIndependentFeature("sf_miasm") {
         document_title("MIASM");
         document_synopsis(
             "This scoring function favors merging transition systems such that in "
@@ -130,7 +131,7 @@ public:
         // TODO: use shrink strategy and limit options from
         // MergeAndShrinkHeuristic instead of having the identical options here
         // again.
-        add_option<shared_ptr<ShrinkStrategy>>(
+        add_option<shared_ptr<TaskIndependentShrinkStrategy>>(
             "shrink_strategy",
             "We recommend setting this to match the shrink strategy configuration "
             "given to {{{merge_and_shrink}}}, see note below.");
@@ -177,10 +178,10 @@ public:
             "true");
     }
 
-    virtual shared_ptr<MergeScoringFunctionMIASM> create_component(
+    virtual shared_ptr<TaskIndependentMergeScoringFunction> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<MergeScoringFunctionMIASM>(
-            opts.get<shared_ptr<ShrinkStrategy>>("shrink_strategy"),
+        return components::make_auto_task_independent_component<MergeScoringFunctionMIASM, MergeScoringFunction>(
+            opts.get<shared_ptr<TaskIndependentShrinkStrategy>>("shrink_strategy"),
             get_transition_system_size_limit_arguments_from_options(opts),
             opts.get<bool>("use_caching"));
     }

--- a/src/search/merge_and_shrink/merge_scoring_function_miasm.h
+++ b/src/search/merge_and_shrink/merge_scoring_function_miasm.h
@@ -25,6 +25,7 @@ class MergeScoringFunctionMIASM : public MergeScoringFunction {
         utils::LogProxy &log) const override;
 public:
     MergeScoringFunctionMIASM(
+        const std::shared_ptr<AbstractTask> &task,
         std::shared_ptr<ShrinkStrategy> shrink_strategy, int max_states,
         int max_states_before_merge, int threshold_before_merge,
         bool use_caching);

--- a/src/search/merge_and_shrink/merge_scoring_function_single_random.cc
+++ b/src/search/merge_and_shrink/merge_scoring_function_single_random.cc
@@ -13,8 +13,8 @@ using namespace std;
 
 namespace merge_and_shrink {
 MergeScoringFunctionSingleRandom::MergeScoringFunctionSingleRandom(
-    int random_seed)
-    : random_seed(random_seed), rng(utils::get_rng(random_seed)) {
+    const shared_ptr<AbstractTask> &task, int random_seed)
+    : MergeScoringFunction(task), random_seed(random_seed), rng(utils::get_rng(random_seed)) {
 }
 
 vector<double> MergeScoringFunctionSingleRandom::compute_scores(
@@ -46,10 +46,11 @@ void MergeScoringFunctionSingleRandom::dump_function_specific_options(
 }
 
 class MergeScoringFunctionSingleRandomFeature
-    : public plugins::TypedFeature<
-          MergeScoringFunction, MergeScoringFunctionSingleRandom> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentMergeScoringFunction> {
 public:
-    MergeScoringFunctionSingleRandomFeature() : TypedFeature("single_random") {
+    MergeScoringFunctionSingleRandomFeature()
+        : TaskIndependentFeature("single_random") {
         document_title("Single random");
         document_synopsis(
             "This scoring function assigns exactly one merge candidate a score of "
@@ -58,10 +59,10 @@ public:
         utils::add_rng_options_to_feature(*this);
     }
 
-    virtual shared_ptr<MergeScoringFunctionSingleRandom> create_component(
+    virtual shared_ptr<TaskIndependentMergeScoringFunction> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<
-            MergeScoringFunctionSingleRandom>(
+        return components::make_auto_task_independent_component<
+            MergeScoringFunctionSingleRandom, MergeScoringFunction>(
             utils::get_rng_arguments_from_options(opts));
     }
 };

--- a/src/search/merge_and_shrink/merge_scoring_function_single_random.h
+++ b/src/search/merge_and_shrink/merge_scoring_function_single_random.h
@@ -18,7 +18,7 @@ class MergeScoringFunctionSingleRandom : public MergeScoringFunction {
     virtual void dump_function_specific_options(
         utils::LogProxy &log) const override;
 public:
-    explicit MergeScoringFunctionSingleRandom(int random_seed);
+    MergeScoringFunctionSingleRandom(const std::shared_ptr<AbstractTask> &task, int random_seed);
     virtual std::vector<double> compute_scores(
         const FactoredTransitionSystem &fts,
         const std::vector<std::pair<int, int>> &merge_candidates) override;

--- a/src/search/merge_and_shrink/merge_scoring_function_total_order.cc
+++ b/src/search/merge_and_shrink/merge_scoring_function_total_order.cc
@@ -17,9 +17,10 @@ using namespace std;
 
 namespace merge_and_shrink {
 MergeScoringFunctionTotalOrder::MergeScoringFunctionTotalOrder(
+    const shared_ptr<AbstractTask> &task,
     AtomicTSOrder atomic_ts_order, ProductTSOrder product_ts_order,
     bool atomic_before_product, int random_seed)
-    : atomic_ts_order(atomic_ts_order),
+    : MergeScoringFunction(task), atomic_ts_order(atomic_ts_order),
       product_ts_order(product_ts_order),
       atomic_before_product(atomic_before_product),
       random_seed(random_seed),
@@ -180,10 +181,10 @@ void MergeScoringFunctionTotalOrder::add_options_to_feature(
 }
 
 class MergeScoringFunctionTotalOrderFeature
-    : public plugins::TypedFeature<
-          MergeScoringFunction, MergeScoringFunctionTotalOrder> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentMergeScoringFunction> {
 public:
-    MergeScoringFunctionTotalOrderFeature() : TypedFeature("total_order") {
+    MergeScoringFunctionTotalOrderFeature() : TaskIndependentFeature("total_order") {
         document_title("Total order");
         document_synopsis(
             "This scoring function computes a total order on the merge candidates, "
@@ -205,10 +206,10 @@ public:
         MergeScoringFunctionTotalOrder::add_options_to_feature(*this);
     }
 
-    virtual shared_ptr<MergeScoringFunctionTotalOrder> create_component(
+    virtual shared_ptr<TaskIndependentMergeScoringFunction> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<
-            MergeScoringFunctionTotalOrder>(
+        return components::make_auto_task_independent_component<
+            MergeScoringFunctionTotalOrder, MergeScoringFunction>(
             opts.get<AtomicTSOrder>("atomic_ts_order"),
             opts.get<ProductTSOrder>("product_ts_order"),
             opts.get<bool>("atomic_before_product"),

--- a/src/search/merge_and_shrink/merge_scoring_function_total_order.h
+++ b/src/search/merge_and_shrink/merge_scoring_function_total_order.h
@@ -38,7 +38,7 @@ class MergeScoringFunctionTotalOrder : public MergeScoringFunction {
     virtual void dump_function_specific_options(
         utils::LogProxy &log) const override;
 public:
-    explicit MergeScoringFunctionTotalOrder(
+    MergeScoringFunctionTotalOrder(const std::shared_ptr<AbstractTask> &task,
         AtomicTSOrder atomic_ts_order, ProductTSOrder product_ts_order,
         bool atomic_before_product, int random_seed);
     virtual std::vector<double> compute_scores(

--- a/src/search/merge_and_shrink/merge_selector.cc
+++ b/src/search/merge_and_shrink/merge_selector.cc
@@ -30,6 +30,10 @@ static vector<pair<int, int>> compute_merge_candidates(
     return merge_candidates;
 }
 
+MergeSelector::MergeSelector(const shared_ptr<AbstractTask> &task)
+    : components::TaskSpecificComponent(task) {
+}
+
 pair<int, int> MergeSelector::select_merge(
     const FactoredTransitionSystem &fts) const {
     return select_merge_from_candidates(fts, compute_merge_candidates(fts));
@@ -44,7 +48,7 @@ void MergeSelector::dump_options(utils::LogProxy &log) const {
 }
 
 static class MergeSelectorCategoryPlugin
-    : public plugins::TypedCategoryPlugin<MergeSelector> {
+    : public plugins::TypedCategoryPlugin<TaskIndependentMergeSelector> {
 public:
     MergeSelectorCategoryPlugin() : TypedCategoryPlugin("MergeSelector") {
         document_synopsis(

--- a/src/search/merge_and_shrink/merge_selector.h
+++ b/src/search/merge_and_shrink/merge_selector.h
@@ -1,6 +1,8 @@
 #ifndef MERGE_AND_SHRINK_MERGE_SELECTOR_H
 #define MERGE_AND_SHRINK_MERGE_SELECTOR_H
 
+#include "../component.h"
+
 #include <string>
 #include <vector>
 
@@ -12,15 +14,14 @@ class LogProxy;
 
 namespace merge_and_shrink {
 class FactoredTransitionSystem;
-class MergeSelector {
+class MergeSelector : public components::TaskSpecificComponent {
 protected:
     virtual std::string name() const = 0;
     virtual void dump_selector_specific_options(utils::LogProxy &) const {
     }
 
 public:
-    MergeSelector() = default;
-    virtual ~MergeSelector() = default;
+    explicit MergeSelector(const std::shared_ptr<AbstractTask> &task);
     // Select a merge candidate from all possible candidates.
     std::pair<int, int> select_merge(const FactoredTransitionSystem &fts) const;
     /*
@@ -35,6 +36,9 @@ public:
     virtual bool requires_init_distances() const = 0;
     virtual bool requires_goal_distances() const = 0;
 };
+
+using TaskIndependentMergeSelector =
+    components::TaskIndependentComponent<MergeSelector>;
 }
 
 #endif

--- a/src/search/merge_and_shrink/merge_selector_score_based_filtering.cc
+++ b/src/search/merge_and_shrink/merge_selector_score_based_filtering.cc
@@ -11,8 +11,9 @@ using namespace std;
 
 namespace merge_and_shrink {
 MergeSelectorScoreBasedFiltering::MergeSelectorScoreBasedFiltering(
+    const shared_ptr<AbstractTask> &task,
     const vector<shared_ptr<MergeScoringFunction>> &scoring_functions)
-    : merge_scoring_functions(scoring_functions) {
+    : MergeSelector(task), merge_scoring_functions(scoring_functions) {
 }
 
 static vector<pair<int, int>> get_remaining_candidates(
@@ -101,26 +102,26 @@ bool MergeSelectorScoreBasedFiltering::requires_goal_distances() const {
 }
 
 class MergeSelectorScoreBasedFilteringFeature
-    : public plugins::TypedFeature<
-          MergeSelector, MergeSelectorScoreBasedFiltering> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentMergeSelector> {
 public:
     MergeSelectorScoreBasedFilteringFeature()
-        : TypedFeature("score_based_filtering") {
+        : TaskIndependentFeature("score_based_filtering") {
         document_title("Score based filtering merge selector");
         document_synopsis(
             "This merge selector has a list of scoring functions, which are used "
             "iteratively to compute scores for merge candidates, keeping the best "
             "ones (with minimal scores) until only one is left.");
 
-        add_list_option<shared_ptr<MergeScoringFunction>>(
+        add_list_option<shared_ptr<TaskIndependentMergeScoringFunction>>(
             "scoring_functions",
             "The list of scoring functions used to compute scores for candidates.");
     }
 
-    virtual shared_ptr<MergeSelectorScoreBasedFiltering> create_component(
+    virtual shared_ptr<TaskIndependentMergeSelector> create_component(
         const plugins::Options &opts) const override {
-        return make_shared<MergeSelectorScoreBasedFiltering>(
-            opts.get_list<shared_ptr<MergeScoringFunction>>(
+        return components::make_auto_task_independent_component<MergeSelectorScoreBasedFiltering, MergeSelector>(
+            opts.get_list<shared_ptr<TaskIndependentMergeScoringFunction>>(
                 "scoring_functions"));
     }
 };

--- a/src/search/merge_and_shrink/merge_selector_score_based_filtering.h
+++ b/src/search/merge_and_shrink/merge_selector_score_based_filtering.h
@@ -20,6 +20,7 @@ protected:
         utils::LogProxy &log) const override;
 public:
     explicit MergeSelectorScoreBasedFiltering(
+        const std::shared_ptr<AbstractTask> &task,
         const std::vector<std::shared_ptr<MergeScoringFunction>>
             &scoring_functions);
     virtual std::pair<int, int> select_merge_from_candidates(

--- a/src/search/merge_and_shrink/merge_strategy_factory.cc
+++ b/src/search/merge_and_shrink/merge_strategy_factory.cc
@@ -7,8 +7,8 @@
 using namespace std;
 
 namespace merge_and_shrink {
-MergeStrategyFactory::MergeStrategyFactory(utils::Verbosity verbosity)
-    : log(utils::get_log_for_verbosity(verbosity)) {
+MergeStrategyFactory::MergeStrategyFactory(const shared_ptr<AbstractTask> &task, utils::Verbosity verbosity)
+    : components::TaskSpecificComponent(task), log(utils::get_log_for_verbosity(verbosity)) {
 }
 
 void MergeStrategyFactory::dump_options() const {
@@ -29,7 +29,7 @@ tuple<utils::Verbosity> get_merge_strategy_arguments_from_options(
 }
 
 static class MergeStrategyFactoryCategoryPlugin
-    : public plugins::TypedCategoryPlugin<MergeStrategyFactory> {
+    : public plugins::TypedCategoryPlugin<TaskIndependentMergeStrategyFactory> {
 public:
     MergeStrategyFactoryCategoryPlugin()
         : TypedCategoryPlugin("MergeStrategy") {

--- a/src/search/merge_and_shrink/merge_strategy_factory.h
+++ b/src/search/merge_and_shrink/merge_strategy_factory.h
@@ -1,6 +1,8 @@
 #ifndef MERGE_AND_SHRINK_MERGE_STRATEGY_FACTORY_H
 #define MERGE_AND_SHRINK_MERGE_STRATEGY_FACTORY_H
 
+#include "../component.h"
+
 #include "../utils/logging.h"
 
 #include <memory>
@@ -17,21 +19,23 @@ namespace merge_and_shrink {
 class FactoredTransitionSystem;
 class MergeStrategy;
 
-class MergeStrategyFactory {
+class MergeStrategyFactory : public components::TaskSpecificComponent {
 protected:
     mutable utils::LogProxy log;
 
     virtual std::string name() const = 0;
     virtual void dump_strategy_specific_options() const = 0;
 public:
-    MergeStrategyFactory(utils::Verbosity verbosity);
-    virtual ~MergeStrategyFactory() = default;
+    MergeStrategyFactory(const std::shared_ptr<AbstractTask> &task, utils::Verbosity verbosity);
     void dump_options() const;
     virtual std::unique_ptr<MergeStrategy> compute_merge_strategy(
         const TaskProxy &task_proxy, const FactoredTransitionSystem &fts) = 0;
     virtual bool requires_init_distances() const = 0;
     virtual bool requires_goal_distances() const = 0;
 };
+
+using TaskIndependentMergeStrategyFactory =
+    components::TaskIndependentComponent<MergeStrategyFactory>;
 
 extern void add_merge_strategy_options_to_feature(plugins::Feature &feature);
 extern std::tuple<utils::Verbosity> get_merge_strategy_arguments_from_options(

--- a/src/search/merge_and_shrink/merge_strategy_factory_precomputed.cc
+++ b/src/search/merge_and_shrink/merge_strategy_factory_precomputed.cc
@@ -10,8 +10,9 @@ using namespace std;
 
 namespace merge_and_shrink {
 MergeStrategyFactoryPrecomputed::MergeStrategyFactoryPrecomputed(
+    const shared_ptr<AbstractTask> &task,
     const shared_ptr<MergeTreeFactory> &merge_tree, utils::Verbosity verbosity)
-    : MergeStrategyFactory(verbosity), merge_tree_factory(merge_tree) {
+    : MergeStrategyFactory(task, verbosity), merge_tree_factory(merge_tree) {
 }
 
 unique_ptr<MergeStrategy>
@@ -41,11 +42,11 @@ void MergeStrategyFactoryPrecomputed::dump_strategy_specific_options() const {
 }
 
 class MergeStrategyFactoryPrecomputedFeature
-    : public plugins::TypedFeature<
-          MergeStrategyFactory, MergeStrategyFactoryPrecomputed> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentMergeStrategyFactory> {
 public:
     MergeStrategyFactoryPrecomputedFeature()
-        : TypedFeature("merge_precomputed") {
+        : TaskIndependentFeature("merge_precomputed") {
         document_title("Precomputed merge strategy");
         document_synopsis(
             "This merge strategy has a precomputed merge tree. Note that this "
@@ -55,7 +56,7 @@ public:
             "with this merge tree, i.e. all merges are performed exactly as given "
             "by the merge tree.");
 
-        add_option<shared_ptr<MergeTreeFactory>>(
+        add_option<shared_ptr<TaskIndependentMergeTreeFactory>>(
             "merge_tree", "The precomputed merge tree.");
         add_merge_strategy_options_to_feature(*this);
 
@@ -67,11 +68,11 @@ public:
             "merge_strategy=merge_precomputed(merge_tree=linear(<variable_order>))"
             "\n}}}");
     }
-    virtual shared_ptr<MergeStrategyFactoryPrecomputed> create_component(
+    virtual shared_ptr<TaskIndependentMergeStrategyFactory> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<
-            MergeStrategyFactoryPrecomputed>(
-            opts.get<shared_ptr<MergeTreeFactory>>("merge_tree"),
+        return components::make_auto_task_independent_component<
+            MergeStrategyFactoryPrecomputed, MergeStrategyFactory>(
+            opts.get<shared_ptr<TaskIndependentMergeTreeFactory>>("merge_tree"),
             get_merge_strategy_arguments_from_options(opts));
     }
 };

--- a/src/search/merge_and_shrink/merge_strategy_factory_precomputed.h
+++ b/src/search/merge_and_shrink/merge_strategy_factory_precomputed.h
@@ -13,6 +13,7 @@ protected:
     virtual void dump_strategy_specific_options() const override;
 public:
     MergeStrategyFactoryPrecomputed(
+        const std::shared_ptr<AbstractTask> &task,
         const std::shared_ptr<MergeTreeFactory> &merge_tree,
         utils::Verbosity verbosity);
     virtual std::unique_ptr<MergeStrategy> compute_merge_strategy(

--- a/src/search/merge_and_shrink/merge_strategy_factory_sccs.cc
+++ b/src/search/merge_and_shrink/merge_strategy_factory_sccs.cc
@@ -32,9 +32,9 @@ static bool compare_sccs_decreasing(
 }
 
 MergeStrategyFactorySCCs::MergeStrategyFactorySCCs(
-    const OrderOfSCCs &order_of_sccs,
+    const shared_ptr<AbstractTask> &task, const OrderOfSCCs &order_of_sccs,
     const shared_ptr<MergeSelector> &merge_selector, utils::Verbosity verbosity)
-    : MergeStrategyFactory(verbosity),
+    : MergeStrategyFactory(task, verbosity),
       order_of_sccs(order_of_sccs),
       merge_selector(merge_selector) {
 }
@@ -137,10 +137,10 @@ string MergeStrategyFactorySCCs::name() const {
 }
 
 class MergeStrategyFactorySCCsFeature
-    : public plugins::TypedFeature<
-          MergeStrategyFactory, MergeStrategyFactorySCCs> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentMergeStrategyFactory> {
 public:
-    MergeStrategyFactorySCCsFeature() : TypedFeature("merge_sccs") {
+    MergeStrategyFactorySCCsFeature() : TaskIndependentFeature("merge_sccs") {
         document_title("Merge strategy SCCs");
         document_synopsis(
             "This merge strategy implements the algorithm described in the paper " +
@@ -162,16 +162,16 @@ public:
 
         add_option<OrderOfSCCs>(
             "order_of_sccs", "how the SCCs should be ordered", "topological");
-        add_option<shared_ptr<MergeSelector>>(
+        add_option<shared_ptr<TaskIndependentMergeSelector>>(
             "merge_selector", "the fallback merge strategy to use");
         add_merge_strategy_options_to_feature(*this);
     }
 
-    virtual shared_ptr<MergeStrategyFactorySCCs> create_component(
+    virtual shared_ptr<TaskIndependentMergeStrategyFactory> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<MergeStrategyFactorySCCs>(
+        return components::make_auto_task_independent_component<MergeStrategyFactorySCCs, MergeStrategyFactory>(
             opts.get<OrderOfSCCs>("order_of_sccs"),
-            opts.get<shared_ptr<MergeSelector>>("merge_selector"),
+            opts.get<shared_ptr<TaskIndependentMergeSelector>>("merge_selector"),
             get_merge_strategy_arguments_from_options(opts));
     }
 };

--- a/src/search/merge_and_shrink/merge_strategy_factory_sccs.h
+++ b/src/search/merge_and_shrink/merge_strategy_factory_sccs.h
@@ -21,6 +21,7 @@ protected:
     virtual void dump_strategy_specific_options() const override;
 public:
     MergeStrategyFactorySCCs(
+        const std::shared_ptr<AbstractTask> &task,
         const OrderOfSCCs &order_of_sccs,
         const std::shared_ptr<MergeSelector> &merge_selector,
         utils::Verbosity verbosity);

--- a/src/search/merge_and_shrink/merge_strategy_factory_stateless.cc
+++ b/src/search/merge_and_shrink/merge_strategy_factory_stateless.cc
@@ -9,8 +9,9 @@ using namespace std;
 
 namespace merge_and_shrink {
 MergeStrategyFactoryStateless::MergeStrategyFactoryStateless(
+    const shared_ptr<AbstractTask> &task,
     const shared_ptr<MergeSelector> &merge_selector, utils::Verbosity verbosity)
-    : MergeStrategyFactory(verbosity), merge_selector(merge_selector) {
+    : MergeStrategyFactory(task, verbosity), merge_selector(merge_selector) {
 }
 
 unique_ptr<MergeStrategy> MergeStrategyFactoryStateless::compute_merge_strategy(
@@ -38,17 +39,17 @@ bool MergeStrategyFactoryStateless::requires_goal_distances() const {
 }
 
 class MergeStrategyFactoryStatelessFeature
-    : public plugins::TypedFeature<
-          MergeStrategyFactory, MergeStrategyFactoryStateless> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentMergeStrategyFactory> {
 public:
-    MergeStrategyFactoryStatelessFeature() : TypedFeature("merge_stateless") {
+    MergeStrategyFactoryStatelessFeature() : TaskIndependentFeature("merge_stateless") {
         document_title("Stateless merge strategy");
         document_synopsis(
             "This merge strategy has a merge selector, which computes the next "
             "merge only depending on the current state of the factored transition "
             "system, not requiring any additional information.");
 
-        add_option<shared_ptr<MergeSelector>>(
+        add_option<shared_ptr<TaskIndependentMergeSelector>>(
             "merge_selector", "The merge selector to be used.");
         add_merge_strategy_options_to_feature(*this);
 
@@ -70,11 +71,11 @@ public:
             "\n}}}");
     }
 
-    virtual shared_ptr<MergeStrategyFactoryStateless> create_component(
+    virtual shared_ptr<TaskIndependentMergeStrategyFactory> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<
-            MergeStrategyFactoryStateless>(
-            opts.get<shared_ptr<MergeSelector>>("merge_selector"),
+        return components::make_auto_task_independent_component<
+            MergeStrategyFactoryStateless, MergeStrategyFactory>(
+            opts.get<shared_ptr<TaskIndependentMergeSelector>>("merge_selector"),
             get_merge_strategy_arguments_from_options(opts));
     }
 };

--- a/src/search/merge_and_shrink/merge_strategy_factory_stateless.h
+++ b/src/search/merge_and_shrink/merge_strategy_factory_stateless.h
@@ -13,6 +13,7 @@ protected:
     virtual void dump_strategy_specific_options() const override;
 public:
     MergeStrategyFactoryStateless(
+        const std::shared_ptr<AbstractTask> &task,
         const std::shared_ptr<MergeSelector> &merge_selector,
         utils::Verbosity verbosity);
     virtual std::unique_ptr<MergeStrategy> compute_merge_strategy(

--- a/src/search/merge_and_shrink/merge_tree_factory.cc
+++ b/src/search/merge_and_shrink/merge_tree_factory.cc
@@ -12,8 +12,8 @@
 using namespace std;
 
 namespace merge_and_shrink {
-MergeTreeFactory::MergeTreeFactory(int random_seed, UpdateOption update_option)
-    : rng(utils::get_rng(random_seed)), update_option(update_option) {
+MergeTreeFactory::MergeTreeFactory(const shared_ptr<AbstractTask> &task, int random_seed, UpdateOption update_option)
+    : components::TaskSpecificComponent(task), rng(utils::get_rng(random_seed)), update_option(update_option) {
 }
 
 void MergeTreeFactory::dump_options(utils::LogProxy &log) const {
@@ -61,7 +61,7 @@ tuple<int, UpdateOption> get_merge_tree_arguments_from_options(
 }
 
 static class MergeTreeFactoryCategoryPlugin
-    : public plugins::TypedCategoryPlugin<MergeTreeFactory> {
+    : public plugins::TypedCategoryPlugin<TaskIndependentMergeTreeFactory> {
 public:
     MergeTreeFactoryCategoryPlugin() : TypedCategoryPlugin("MergeTree") {
         document_synopsis(

--- a/src/search/merge_and_shrink/merge_tree_factory.h
+++ b/src/search/merge_and_shrink/merge_tree_factory.h
@@ -1,6 +1,8 @@
 #ifndef MERGE_AND_SHRINK_MERGE_TREE_FACTORY_H
 #define MERGE_AND_SHRINK_MERGE_TREE_FACTORY_H
 
+#include "../component.h"
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -22,7 +24,7 @@ class FactoredTransitionSystem;
 class MergeTree;
 enum class UpdateOption;
 
-class MergeTreeFactory {
+class MergeTreeFactory : public components::TaskSpecificComponent {
 protected:
     std::shared_ptr<utils::RandomNumberGenerator> rng;
     UpdateOption update_option;
@@ -30,8 +32,7 @@ protected:
     virtual void dump_tree_specific_options(utils::LogProxy &) const {
     }
 public:
-    MergeTreeFactory(int random_seed, UpdateOption update_option);
-    virtual ~MergeTreeFactory() = default;
+    MergeTreeFactory(const std::shared_ptr<AbstractTask> &task, int random_seed, UpdateOption update_option);
     void dump_options(utils::LogProxy &log) const;
     // Compute a merge tree for the given entire task.
     virtual std::unique_ptr<MergeTree> compute_merge_tree(
@@ -44,6 +45,9 @@ public:
     virtual bool requires_init_distances() const = 0;
     virtual bool requires_goal_distances() const = 0;
 };
+
+using TaskIndependentMergeTreeFactory =
+    components::TaskIndependentComponent<MergeTreeFactory>;
 
 // Derived classes must call this method in their parsing methods.
 extern void add_merge_tree_options_to_feature(plugins::Feature &feature);

--- a/src/search/merge_and_shrink/merge_tree_factory_linear.cc
+++ b/src/search/merge_and_shrink/merge_tree_factory_linear.cc
@@ -18,9 +18,10 @@ using namespace std;
 
 namespace merge_and_shrink {
 MergeTreeFactoryLinear::MergeTreeFactoryLinear(
+    const shared_ptr<AbstractTask> &task,
     variable_order_finder::VariableOrderType variable_order, int random_seed,
     UpdateOption update_option)
-    : MergeTreeFactory(random_seed, update_option),
+    : MergeTreeFactory(task, random_seed, update_option),
       variable_order_type(variable_order) {
 }
 
@@ -117,9 +118,9 @@ void MergeTreeFactoryLinear::add_options_to_feature(plugins::Feature &feature) {
 }
 
 class MergeTreeFactoryLinearFeature
-    : public plugins::TypedFeature<MergeTreeFactory, MergeTreeFactoryLinear> {
+    : public plugins::TaskIndependentFeature<TaskIndependentMergeTreeFactory> {
 public:
-    MergeTreeFactoryLinearFeature() : TypedFeature("linear") {
+    MergeTreeFactoryLinearFeature() : TaskIndependentFeature("linear") {
         document_title("Linear merge trees");
         document_synopsis(
             "These merge trees implement several linear merge orders, which "
@@ -135,9 +136,9 @@ public:
         MergeTreeFactoryLinear::add_options_to_feature(*this);
     }
 
-    virtual shared_ptr<MergeTreeFactoryLinear> create_component(
+    virtual shared_ptr<TaskIndependentMergeTreeFactory> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<MergeTreeFactoryLinear>(
+        return components::make_auto_task_independent_component<MergeTreeFactoryLinear, MergeTreeFactory>(
             opts.get<variable_order_finder::VariableOrderType>(
                 "variable_order"),
             get_merge_tree_arguments_from_options(opts));

--- a/src/search/merge_and_shrink/merge_tree_factory_linear.h
+++ b/src/search/merge_and_shrink/merge_tree_factory_linear.h
@@ -19,6 +19,7 @@ protected:
         utils::LogProxy &log) const override;
 public:
     MergeTreeFactoryLinear(
+        const std::shared_ptr<AbstractTask> &task,
         variable_order_finder::VariableOrderType variable_order,
         int random_seed, UpdateOption update_option);
     virtual std::unique_ptr<MergeTree> compute_merge_tree(

--- a/src/search/merge_and_shrink/shrink_bisimulation.cc
+++ b/src/search/merge_and_shrink/shrink_bisimulation.cc
@@ -90,8 +90,8 @@ struct Signature {
     }
 };
 
-ShrinkBisimulation::ShrinkBisimulation(bool greedy, AtLimit at_limit)
-    : greedy(greedy), at_limit(at_limit) {
+ShrinkBisimulation::ShrinkBisimulation(const shared_ptr<AbstractTask> &task, bool greedy, AtLimit at_limit)
+    : ShrinkStrategy(task), greedy(greedy), at_limit(at_limit) {
 }
 
 int ShrinkBisimulation::initialize_groups(
@@ -371,9 +371,9 @@ void ShrinkBisimulation::dump_strategy_specific_options(
 }
 
 class ShrinkBisimulationFeature
-    : public plugins::TypedFeature<ShrinkStrategy, ShrinkBisimulation> {
+    : public plugins::TaskIndependentFeature<TaskIndependentShrinkStrategy> {
 public:
-    ShrinkBisimulationFeature() : TypedFeature("shrink_bisimulation") {
+    ShrinkBisimulationFeature() : TaskIndependentFeature("shrink_bisimulation") {
         document_title("Bismulation based shrink strategy");
         document_synopsis(
             "This shrink strategy implements the algorithm described in"
@@ -414,9 +414,9 @@ public:
             "merging).");
     }
 
-    virtual shared_ptr<ShrinkBisimulation> create_component(
+    virtual shared_ptr<TaskIndependentShrinkStrategy> create_component(
         const plugins::Options &opts) const override {
-        return make_shared<ShrinkBisimulation>(
+        return components::make_auto_task_independent_component<ShrinkBisimulation, ShrinkStrategy>(
             opts.get<bool>("greedy"), opts.get<AtLimit>("at_limit"));
     }
 };

--- a/src/search/merge_and_shrink/shrink_bisimulation.h
+++ b/src/search/merge_and_shrink/shrink_bisimulation.h
@@ -32,7 +32,7 @@ protected:
         utils::LogProxy &log) const override;
     virtual std::string name() const override;
 public:
-    explicit ShrinkBisimulation(bool greedy, AtLimit at_limit);
+    ShrinkBisimulation(const std::shared_ptr<AbstractTask> &task, bool greedy, AtLimit at_limit);
     virtual StateEquivalenceRelation compute_equivalence_relation(
         const TransitionSystem &ts, const Distances &distances, int target_size,
         utils::LogProxy &log) const override;

--- a/src/search/merge_and_shrink/shrink_bucket_based.cc
+++ b/src/search/merge_and_shrink/shrink_bucket_based.cc
@@ -12,8 +12,8 @@
 using namespace std;
 
 namespace merge_and_shrink {
-ShrinkBucketBased::ShrinkBucketBased(int random_seed)
-    : rng(utils::get_rng(random_seed)) {
+ShrinkBucketBased::ShrinkBucketBased(const shared_ptr<AbstractTask> &task, int random_seed)
+    : ShrinkStrategy(task), rng(utils::get_rng(random_seed)) {
 }
 
 StateEquivalenceRelation ShrinkBucketBased::compute_abstraction(

--- a/src/search/merge_and_shrink/shrink_bucket_based.h
+++ b/src/search/merge_and_shrink/shrink_bucket_based.h
@@ -49,7 +49,7 @@ protected:
     virtual std::vector<Bucket> partition_into_buckets(
         const TransitionSystem &ts, const Distances &Distances) const = 0;
 public:
-    explicit ShrinkBucketBased(int random_seed);
+    explicit ShrinkBucketBased(const std::shared_ptr<AbstractTask> &task, int random_seed);
     virtual StateEquivalenceRelation compute_equivalence_relation(
         const TransitionSystem &ts, const Distances &distances, int target_size,
         utils::LogProxy &log) const override;

--- a/src/search/merge_and_shrink/shrink_fh.cc
+++ b/src/search/merge_and_shrink/shrink_fh.cc
@@ -19,8 +19,8 @@
 using namespace std;
 
 namespace merge_and_shrink {
-ShrinkFH::ShrinkFH(HighLow shrink_f, HighLow shrink_h, int random_seed)
-    : ShrinkBucketBased(random_seed), f_start(shrink_f), h_start(shrink_h) {
+ShrinkFH::ShrinkFH(const shared_ptr<AbstractTask> &task, HighLow shrink_f, HighLow shrink_h, int random_seed)
+    : ShrinkBucketBased(task, random_seed), f_start(shrink_f), h_start(shrink_h) {
 }
 
 vector<ShrinkBucketBased::Bucket> ShrinkFH::partition_into_buckets(
@@ -183,9 +183,9 @@ void ShrinkFH::dump_strategy_specific_options(utils::LogProxy &log) const {
     }
 }
 
-class ShrinkFHFeature : public plugins::TypedFeature<ShrinkStrategy, ShrinkFH> {
+class ShrinkFHFeature : public plugins::TaskIndependentFeature<TaskIndependentShrinkStrategy> {
 public:
-    ShrinkFHFeature() : TypedFeature("shrink_fh") {
+    ShrinkFHFeature() : TaskIndependentFeature("shrink_fh") {
         document_title("f-preserving shrink strategy");
         document_synopsis(
             "This shrink strategy implements the algorithm described in"
@@ -235,9 +235,9 @@ public:
             "vector-based approach.");
     }
 
-    virtual shared_ptr<ShrinkFH> create_component(
+    virtual shared_ptr<TaskIndependentShrinkStrategy> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<ShrinkFH>(
+        return components::make_auto_task_independent_component<ShrinkFH, ShrinkStrategy>(
             opts.get<ShrinkFH::HighLow>("shrink_f"),
             opts.get<ShrinkFH::HighLow>("shrink_h"),
             get_shrink_bucket_arguments_from_options(opts));

--- a/src/search/merge_and_shrink/shrink_fh.h
+++ b/src/search/merge_and_shrink/shrink_fh.h
@@ -46,7 +46,7 @@ protected:
         const TransitionSystem &ts, const Distances &distances) const override;
 
 public:
-    ShrinkFH(HighLow shrink_f, HighLow shrink_h, int random_seed);
+    ShrinkFH(const std::shared_ptr<AbstractTask> &task, HighLow shrink_f, HighLow shrink_h, int random_seed);
 
     virtual bool requires_init_distances() const override {
         return true;

--- a/src/search/merge_and_shrink/shrink_random.cc
+++ b/src/search/merge_and_shrink/shrink_random.cc
@@ -11,7 +11,8 @@
 using namespace std;
 
 namespace merge_and_shrink {
-ShrinkRandom::ShrinkRandom(int random_seed) : ShrinkBucketBased(random_seed) {
+ShrinkRandom::ShrinkRandom(const shared_ptr<AbstractTask> &task, int random_seed)
+    : ShrinkBucketBased(task, random_seed) {
 }
 
 vector<ShrinkBucketBased::Bucket> ShrinkRandom::partition_into_buckets(
@@ -32,18 +33,18 @@ string ShrinkRandom::name() const {
 }
 
 class ShrinkRandomFeature
-    : public plugins::TypedFeature<ShrinkStrategy, ShrinkRandom> {
+    : public plugins::TaskIndependentFeature<TaskIndependentShrinkStrategy> {
 public:
-    ShrinkRandomFeature() : TypedFeature("shrink_random") {
+    ShrinkRandomFeature() : TaskIndependentFeature("shrink_random") {
         document_title("Random");
         document_synopsis("");
 
         add_shrink_bucket_options_to_feature(*this);
     }
 
-    virtual shared_ptr<ShrinkRandom> create_component(
+    virtual shared_ptr<TaskIndependentShrinkStrategy> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<ShrinkRandom>(
+        return components::make_auto_task_independent_component<ShrinkRandom, ShrinkStrategy>(
             get_shrink_bucket_arguments_from_options(opts));
     }
 };

--- a/src/search/merge_and_shrink/shrink_random.h
+++ b/src/search/merge_and_shrink/shrink_random.h
@@ -13,7 +13,7 @@ protected:
     void dump_strategy_specific_options(utils::LogProxy &) const override {
     }
 public:
-    explicit ShrinkRandom(int random_seed);
+    ShrinkRandom(const std::shared_ptr<AbstractTask> &task, int random_seed);
 
     virtual bool requires_init_distances() const override {
         return false;

--- a/src/search/merge_and_shrink/shrink_strategy.cc
+++ b/src/search/merge_and_shrink/shrink_strategy.cc
@@ -11,6 +11,10 @@
 using namespace std;
 
 namespace merge_and_shrink {
+ShrinkStrategy::ShrinkStrategy(const shared_ptr<AbstractTask> &task)
+    : components::TaskSpecificComponent(task) {
+}
+
 void ShrinkStrategy::dump_options(utils::LogProxy &log) const {
     if (log.is_at_least_normal()) {
         log << "Shrink strategy options: " << endl;
@@ -24,7 +28,7 @@ string ShrinkStrategy::get_name() const {
 }
 
 static class ShrinkStrategyCategoryPlugin
-    : public plugins::TypedCategoryPlugin<ShrinkStrategy> {
+    : public plugins::TypedCategoryPlugin<TaskIndependentShrinkStrategy> {
 public:
     ShrinkStrategyCategoryPlugin() : TypedCategoryPlugin("ShrinkStrategy") {
         document_synopsis(

--- a/src/search/merge_and_shrink/shrink_strategy.h
+++ b/src/search/merge_and_shrink/shrink_strategy.h
@@ -3,6 +3,8 @@
 
 #include "types.h"
 
+#include "../component.h"
+
 #include <string>
 #include <vector>
 
@@ -14,13 +16,12 @@ namespace merge_and_shrink {
 class Distances;
 class TransitionSystem;
 
-class ShrinkStrategy {
+class ShrinkStrategy : public components::TaskSpecificComponent {
 protected:
     virtual std::string name() const = 0;
     virtual void dump_strategy_specific_options(utils::LogProxy &log) const = 0;
 public:
-    ShrinkStrategy() = default;
-    virtual ~ShrinkStrategy() = default;
+    explicit ShrinkStrategy(const std::shared_ptr<AbstractTask> &task);
 
     /*
       Compute a state equivalence relation over the states of the given
@@ -45,6 +46,9 @@ public:
     void dump_options(utils::LogProxy &log) const;
     std::string get_name() const;
 };
+
+using TaskIndependentShrinkStrategy =
+    components::TaskIndependentComponent<ShrinkStrategy>;
 }
 
 #endif

--- a/src/search/open_list_factory.cc
+++ b/src/search/open_list_factory.cc
@@ -5,6 +5,10 @@
 
 using namespace std;
 
+OpenListFactory::OpenListFactory(const shared_ptr<AbstractTask> &task)
+    : components::TaskSpecificComponent(task) {
+}
+
 template<>
 unique_ptr<StateOpenList> OpenListFactory::create_open_list() {
     return create_state_open_list();
@@ -26,7 +30,7 @@ tuple<bool> get_open_list_arguments_from_options(const plugins::Options &opts) {
 }
 
 static class OpenListFactoryCategoryPlugin
-    : public plugins::TypedCategoryPlugin<OpenListFactory> {
+    : public plugins::TypedCategoryPlugin<TaskIndependentOpenListFactory> {
 public:
     OpenListFactoryCategoryPlugin() : TypedCategoryPlugin("OpenList") {
         // TODO: use document_synopsis() for the wiki page.

--- a/src/search/open_list_factory.h
+++ b/src/search/open_list_factory.h
@@ -1,17 +1,17 @@
 #ifndef OPEN_LIST_FACTORY_H
 #define OPEN_LIST_FACTORY_H
 
+#include "component.h"
 #include "open_list.h"
 
 #include "plugins/plugin.h"
 
 #include <memory>
 
-class OpenListFactory {
+class OpenListFactory : public components::TaskSpecificComponent {
+protected:
+    explicit OpenListFactory(const std::shared_ptr<AbstractTask> &task);
 public:
-    OpenListFactory() = default;
-    virtual ~OpenListFactory() = default;
-
     OpenListFactory(const OpenListFactory &) = delete;
 
     virtual std::unique_ptr<StateOpenList> create_state_open_list() = 0;
@@ -26,6 +26,9 @@ public:
     template<typename T>
     std::unique_ptr<OpenList<T>> create_open_list();
 };
+
+using TaskIndependentOpenListFactory =
+    components::TaskIndependentComponent<OpenListFactory>;
 
 extern void add_open_list_options_to_feature(plugins::Feature &feature);
 extern std::tuple<bool> get_open_list_arguments_from_options(

--- a/src/search/open_lists/alternation_open_list.cc
+++ b/src/search/open_lists/alternation_open_list.cc
@@ -125,8 +125,9 @@ bool AlternationOpenList<Entry>::is_reliable_dead_end(
 }
 
 AlternationOpenListFactory::AlternationOpenListFactory(
+    const shared_ptr<AbstractTask> &task,
     const vector<shared_ptr<OpenListFactory>> &sublists, int boost)
-    : sublists(sublists), boost(boost) {
+    : OpenListFactory(task), sublists(sublists), boost(boost) {
     utils::verify_list_not_empty(sublists, "sublists");
 }
 
@@ -140,13 +141,13 @@ unique_ptr<EdgeOpenList> AlternationOpenListFactory::create_edge_open_list() {
 }
 
 class AlternationOpenListFeature
-    : public plugins::TypedFeature<
-          OpenListFactory, AlternationOpenListFactory> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentOpenListFactory> {
 public:
-    AlternationOpenListFeature() : TypedFeature("alt") {
+    AlternationOpenListFeature() : TaskIndependentFeature("alt") {
         document_title("Alternation open list");
         document_synopsis("Alternates between several open lists.");
-        add_list_option<shared_ptr<OpenListFactory>>(
+        add_list_option<shared_ptr<TaskIndependentOpenListFactory>>(
             "sublists", "open lists between which this one alternates");
         add_option<int>(
             "boost",
@@ -155,10 +156,10 @@ public:
             "0");
     }
 
-    virtual shared_ptr<AlternationOpenListFactory> create_component(
+    virtual shared_ptr<TaskIndependentOpenListFactory> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<AlternationOpenListFactory>(
-            opts.get_list<shared_ptr<OpenListFactory>>("sublists"),
+        return components::make_auto_task_independent_component<AlternationOpenListFactory, OpenListFactory>(
+            opts.get_list<shared_ptr<TaskIndependentOpenListFactory>>("sublists"),
             opts.get<int>("boost"));
     }
 };

--- a/src/search/open_lists/alternation_open_list.h
+++ b/src/search/open_lists/alternation_open_list.h
@@ -9,6 +9,7 @@ class AlternationOpenListFactory : public OpenListFactory {
     int boost;
 public:
     AlternationOpenListFactory(
+        const std::shared_ptr<AbstractTask> &task,
         const std::vector<std::shared_ptr<OpenListFactory>> &sublists,
         int boost);
 

--- a/src/search/open_lists/best_first_open_list.cc
+++ b/src/search/open_lists/best_first_open_list.cc
@@ -97,8 +97,8 @@ bool BestFirstOpenList<Entry>::is_reliable_dead_end(
 }
 
 BestFirstOpenListFactory::BestFirstOpenListFactory(
-    const shared_ptr<Evaluator> &eval, bool pref_only)
-    : eval(eval), pref_only(pref_only) {
+    const shared_ptr<AbstractTask> &task, const shared_ptr<Evaluator> &eval, bool pref_only)
+    : OpenListFactory(task), eval(eval), pref_only(pref_only) {
 }
 
 unique_ptr<StateOpenList> BestFirstOpenListFactory::create_state_open_list() {
@@ -110,14 +110,14 @@ unique_ptr<EdgeOpenList> BestFirstOpenListFactory::create_edge_open_list() {
 }
 
 class BestFirstOpenListFeature
-    : public plugins::TypedFeature<OpenListFactory, BestFirstOpenListFactory> {
+    : public plugins::TaskIndependentFeature<TaskIndependentOpenListFactory> {
 public:
-    BestFirstOpenListFeature() : TypedFeature("single") {
+    BestFirstOpenListFeature() : TaskIndependentFeature("single") {
         document_title("Best-first open list");
         document_synopsis(
             "Open list that uses a single evaluator and FIFO tiebreaking.");
 
-        add_option<shared_ptr<Evaluator>>("eval", "evaluator");
+        add_option<shared_ptr<TaskIndependentEvaluator>>("eval", "evaluator");
         add_open_list_options_to_feature(*this);
 
         document_note(
@@ -129,10 +129,10 @@ public:
             "takes time O(log(n)), where n is the number of buckets.");
     }
 
-    virtual shared_ptr<BestFirstOpenListFactory> create_component(
+    virtual shared_ptr<TaskIndependentOpenListFactory> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<BestFirstOpenListFactory>(
-            opts.get<shared_ptr<Evaluator>>("eval"),
+        return components::make_auto_task_independent_component<BestFirstOpenListFactory, OpenListFactory>(
+            opts.get<shared_ptr<TaskIndependentEvaluator>>("eval"),
             get_open_list_arguments_from_options(opts));
     }
 };

--- a/src/search/open_lists/best_first_open_list.h
+++ b/src/search/open_lists/best_first_open_list.h
@@ -15,6 +15,7 @@ class BestFirstOpenListFactory : public OpenListFactory {
     bool pref_only;
 public:
     BestFirstOpenListFactory(
+        const std::shared_ptr<AbstractTask> &task,
         const std::shared_ptr<Evaluator> &eval, bool pref_only);
 
     virtual std::unique_ptr<StateOpenList> create_state_open_list() override;

--- a/src/search/open_lists/epsilon_greedy_open_list.cc
+++ b/src/search/open_lists/epsilon_greedy_open_list.cc
@@ -138,9 +138,10 @@ void EpsilonGreedyOpenList<Entry>::clear() {
 }
 
 EpsilonGreedyOpenListFactory::EpsilonGreedyOpenListFactory(
+    const shared_ptr<AbstractTask> &task,
     const shared_ptr<Evaluator> &eval, double epsilon, int random_seed,
     bool pref_only)
-    : eval(eval),
+    : OpenListFactory(task), eval(eval),
       epsilon(epsilon),
       random_seed(random_seed),
       pref_only(pref_only) {
@@ -158,10 +159,10 @@ unique_ptr<EdgeOpenList> EpsilonGreedyOpenListFactory::create_edge_open_list() {
 }
 
 class EpsilonGreedyOpenListFeature
-    : public plugins::TypedFeature<
-          OpenListFactory, EpsilonGreedyOpenListFactory> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentOpenListFactory> {
 public:
-    EpsilonGreedyOpenListFeature() : TypedFeature("epsilon_greedy") {
+    EpsilonGreedyOpenListFeature() : TaskIndependentFeature("epsilon_greedy") {
         document_title("Epsilon-greedy open list");
         document_synopsis(
             "Chooses an entry uniformly randomly with probability "
@@ -177,7 +178,7 @@ public:
                 " on Automated Planning and Scheduling (ICAPS 2014)",
                 "375-379", "AAAI Press", "2014"));
 
-        add_option<shared_ptr<Evaluator>>("eval", "evaluator");
+        add_option<shared_ptr<TaskIndependentEvaluator>>("eval", "evaluator");
         add_option<double>(
             "epsilon", "probability for choosing the next entry randomly",
             "0.2", plugins::Bounds("0.0", "1.0"));
@@ -185,11 +186,11 @@ public:
         add_open_list_options_to_feature(*this);
     }
 
-    virtual shared_ptr<EpsilonGreedyOpenListFactory> create_component(
+    virtual shared_ptr<TaskIndependentOpenListFactory> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<
-            EpsilonGreedyOpenListFactory>(
-            opts.get<shared_ptr<Evaluator>>("eval"),
+        return components::make_auto_task_independent_component<
+            EpsilonGreedyOpenListFactory, OpenListFactory>(
+            opts.get<shared_ptr<TaskIndependentEvaluator>>("eval"),
             opts.get<double>("epsilon"),
             utils::get_rng_arguments_from_options(opts),
             get_open_list_arguments_from_options(opts));

--- a/src/search/open_lists/epsilon_greedy_open_list.h
+++ b/src/search/open_lists/epsilon_greedy_open_list.h
@@ -48,6 +48,7 @@ class EpsilonGreedyOpenListFactory : public OpenListFactory {
     bool pref_only;
 public:
     EpsilonGreedyOpenListFactory(
+        const std::shared_ptr<AbstractTask> &task,
         const std::shared_ptr<Evaluator> &eval, double epsilon, int random_seed,
         bool pref_only);
 

--- a/src/search/open_lists/pareto_open_list.cc
+++ b/src/search/open_lists/pareto_open_list.cc
@@ -221,9 +221,10 @@ bool ParetoOpenList<Entry>::is_reliable_dead_end(
 }
 
 ParetoOpenListFactory::ParetoOpenListFactory(
+    const shared_ptr<AbstractTask> &task,
     const vector<shared_ptr<Evaluator>> &evals, bool state_uniform_selection,
     int random_seed, bool pref_only)
-    : evals(evals),
+    : OpenListFactory(task), evals(evals),
       state_uniform_selection(state_uniform_selection),
       random_seed(random_seed),
       pref_only(pref_only) {
@@ -240,15 +241,15 @@ unique_ptr<EdgeOpenList> ParetoOpenListFactory::create_edge_open_list() {
 }
 
 class ParetoOpenListFeature
-    : public plugins::TypedFeature<OpenListFactory, ParetoOpenListFactory> {
+    : public plugins::TaskIndependentFeature<TaskIndependentOpenListFactory> {
 public:
-    ParetoOpenListFeature() : TypedFeature("pareto") {
+    ParetoOpenListFeature() : TaskIndependentFeature("pareto") {
         document_title("Pareto open list");
         document_synopsis(
             "Selects one of the Pareto-optimal (regarding the sub-evaluators) "
             "entries for removal.");
 
-        add_list_option<shared_ptr<Evaluator>>("evals", "evaluators");
+        add_list_option<shared_ptr<TaskIndependentEvaluator>>("evals", "evaluators");
         add_option<bool>(
             "state_uniform_selection",
             "When removing an entry, we select a non-dominated bucket "
@@ -260,10 +261,10 @@ public:
         add_open_list_options_to_feature(*this);
     }
 
-    virtual shared_ptr<ParetoOpenListFactory> create_component(
+    virtual shared_ptr<TaskIndependentOpenListFactory> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<ParetoOpenListFactory>(
-            opts.get_list<shared_ptr<Evaluator>>("evals"),
+        return components::make_auto_task_independent_component<ParetoOpenListFactory, OpenListFactory>(
+            opts.get_list<shared_ptr<TaskIndependentEvaluator>>("evals"),
             opts.get<bool>("state_uniform_selection"),
             utils::get_rng_arguments_from_options(opts),
             get_open_list_arguments_from_options(opts));

--- a/src/search/open_lists/pareto_open_list.h
+++ b/src/search/open_lists/pareto_open_list.h
@@ -11,6 +11,7 @@ class ParetoOpenListFactory : public OpenListFactory {
     bool pref_only;
 public:
     ParetoOpenListFactory(
+        const std::shared_ptr<AbstractTask> &task,
         const std::vector<std::shared_ptr<Evaluator>> &evals,
         bool state_uniform_selection, int random_seed, bool pref_only);
 

--- a/src/search/open_lists/tiebreaking_open_list.cc
+++ b/src/search/open_lists/tiebreaking_open_list.cc
@@ -141,9 +141,10 @@ bool TieBreakingOpenList<Entry>::is_reliable_dead_end(
 }
 
 TieBreakingOpenListFactory::TieBreakingOpenListFactory(
+    const shared_ptr<AbstractTask> &task,
     const vector<shared_ptr<Evaluator>> &evals, bool unsafe_pruning,
     bool pref_only)
-    : evals(evals), unsafe_pruning(unsafe_pruning), pref_only(pref_only) {
+    : OpenListFactory(task), evals(evals), unsafe_pruning(unsafe_pruning), pref_only(pref_only) {
     utils::verify_list_not_empty(evals, "evals");
 }
 
@@ -158,14 +159,13 @@ unique_ptr<EdgeOpenList> TieBreakingOpenListFactory::create_edge_open_list() {
 }
 
 class TieBreakingOpenListFeature
-    : public plugins::TypedFeature<
-          OpenListFactory, TieBreakingOpenListFactory> {
+    : public plugins::TaskIndependentFeature<TaskIndependentOpenListFactory> {
 public:
-    TieBreakingOpenListFeature() : TypedFeature("tiebreaking") {
+    TieBreakingOpenListFeature() : TaskIndependentFeature("tiebreaking") {
         document_title("Tie-breaking open list");
         document_synopsis("");
 
-        add_list_option<shared_ptr<Evaluator>>("evals", "evaluators");
+        add_list_option<shared_ptr<TaskIndependentEvaluator>>("evals", "evaluators");
         add_option<bool>(
             "unsafe_pruning",
             "allow unsafe pruning when the main evaluator regards a state a dead end",
@@ -173,10 +173,10 @@ public:
         add_open_list_options_to_feature(*this);
     }
 
-    virtual shared_ptr<TieBreakingOpenListFactory> create_component(
+    virtual shared_ptr<TaskIndependentOpenListFactory> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<TieBreakingOpenListFactory>(
-            opts.get_list<shared_ptr<Evaluator>>("evals"),
+        return components::make_auto_task_independent_component<TieBreakingOpenListFactory, OpenListFactory>(
+            opts.get_list<shared_ptr<TaskIndependentEvaluator>>("evals"),
             opts.get<bool>("unsafe_pruning"),
             get_open_list_arguments_from_options(opts));
     }

--- a/src/search/open_lists/tiebreaking_open_list.h
+++ b/src/search/open_lists/tiebreaking_open_list.h
@@ -10,6 +10,7 @@ class TieBreakingOpenListFactory : public OpenListFactory {
     bool pref_only;
 public:
     TieBreakingOpenListFactory(
+        const std::shared_ptr<AbstractTask> &task,
         const std::vector<std::shared_ptr<Evaluator>> &evals,
         bool unsafe_pruning, bool pref_only);
 

--- a/src/search/open_lists/type_based_open_list.cc
+++ b/src/search/open_lists/type_based_open_list.cc
@@ -135,8 +135,9 @@ void TypeBasedOpenList<Entry>::get_path_dependent_evaluators(
 }
 
 TypeBasedOpenListFactory::TypeBasedOpenListFactory(
+    const shared_ptr<AbstractTask> &task,
     const vector<shared_ptr<Evaluator>> &evaluators, int random_seed)
-    : evaluators(evaluators), random_seed(random_seed) {
+    : OpenListFactory(task), evaluators(evaluators), random_seed(random_seed) {
     utils::verify_list_not_empty(evaluators, "evaluators");
 }
 
@@ -151,9 +152,9 @@ unique_ptr<EdgeOpenList> TypeBasedOpenListFactory::create_edge_open_list() {
 }
 
 class TypeBasedOpenListFeature
-    : public plugins::TypedFeature<OpenListFactory, TypeBasedOpenListFactory> {
+    : public plugins::TaskIndependentFeature<TaskIndependentOpenListFactory> {
 public:
-    TypeBasedOpenListFeature() : TypedFeature("type_based") {
+    TypeBasedOpenListFeature() : TaskIndependentFeature("type_based") {
         document_title("Type-based open list");
         document_synopsis(
             "Uses multiple evaluators to assign entries to buckets. "
@@ -171,16 +172,16 @@ public:
                 " on Artificial Intelligence (AAAI 2014)",
                 "2395-2401", "AAAI Press", "2014"));
 
-        add_list_option<shared_ptr<Evaluator>>(
+        add_list_option<shared_ptr<TaskIndependentEvaluator>>(
             "evaluators",
             "Evaluators used to determine the bucket for each entry.");
         utils::add_rng_options_to_feature(*this);
     }
 
-    virtual shared_ptr<TypeBasedOpenListFactory> create_component(
+    virtual shared_ptr<TaskIndependentOpenListFactory> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<TypeBasedOpenListFactory>(
-            opts.get_list<shared_ptr<Evaluator>>("evaluators"),
+        return components::make_auto_task_independent_component<TypeBasedOpenListFactory, OpenListFactory>(
+            opts.get_list<shared_ptr<TaskIndependentEvaluator>>("evaluators"),
             utils::get_rng_arguments_from_options(opts));
     }
 };

--- a/src/search/open_lists/type_based_open_list.h
+++ b/src/search/open_lists/type_based_open_list.h
@@ -28,6 +28,7 @@ class TypeBasedOpenListFactory : public OpenListFactory {
     int random_seed;
 public:
     TypeBasedOpenListFactory(
+        const std::shared_ptr<AbstractTask> &task,
         const std::vector<std::shared_ptr<Evaluator>> &evaluators,
         int random_seed);
 

--- a/src/search/operator_counting/constraint_generator.cc
+++ b/src/search/operator_counting/constraint_generator.cc
@@ -5,12 +5,16 @@
 using namespace std;
 
 namespace operator_counting {
+ConstraintGenerator::ConstraintGenerator(const shared_ptr<AbstractTask> &task)
+    : components::TaskSpecificComponent(task) {
+}
+
 void ConstraintGenerator::initialize_constraints(
     const shared_ptr<AbstractTask> &, lp::LinearProgram &) {
 }
 
 static class ConstraintGeneratorCategoryPlugin
-    : public plugins::TypedCategoryPlugin<ConstraintGenerator> {
+    : public plugins::TypedCategoryPlugin<TaskIndependentConstraintGenerator> {
 public:
     ConstraintGeneratorCategoryPlugin()
         : TypedCategoryPlugin("ConstraintGenerator") {

--- a/src/search/operator_counting/constraint_generator.h
+++ b/src/search/operator_counting/constraint_generator.h
@@ -1,6 +1,8 @@
 #ifndef OPERATOR_COUNTING_CONSTRAINT_GENERATOR_H
 #define OPERATOR_COUNTING_CONSTRAINT_GENERATOR_H
 
+#include "../component.h"
+
 #include "../algorithms/named_vector.h"
 
 #include <memory>
@@ -29,9 +31,9 @@ namespace operator_counting {
       Example: constraints from landmarks generated for a given state, e.g.
       using the LM-Cut method.
 */
-class ConstraintGenerator {
+class ConstraintGenerator : public components::TaskSpecificComponent {
 public:
-    virtual ~ConstraintGenerator() = default;
+    explicit ConstraintGenerator(const std::shared_ptr<AbstractTask> &task);
 
     /*
       Called upon initialization for the given task. Use this to add permanent
@@ -50,6 +52,9 @@ public:
     virtual bool update_constraints(
         const State &state, lp::LPSolver &lp_solver) = 0;
 };
+
+using TaskIndependentConstraintGenerator =
+    components::TaskIndependentComponent<ConstraintGenerator>;
 }
 
 #endif

--- a/src/search/operator_counting/delete_relaxation_if_constraints.cc
+++ b/src/search/operator_counting/delete_relaxation_if_constraints.cc
@@ -21,8 +21,8 @@ static void add_lp_variables(
 }
 
 DeleteRelaxationIFConstraints::DeleteRelaxationIFConstraints(
-    bool use_time_vars, bool use_integer_vars)
-    : use_time_vars(use_time_vars), use_integer_vars(use_integer_vars) {
+    const shared_ptr<AbstractTask> &task, bool use_time_vars, bool use_integer_vars)
+    : ConstraintGenerator(task), use_time_vars(use_time_vars), use_integer_vars(use_integer_vars) {
 }
 
 int DeleteRelaxationIFConstraints::get_var_op_used(const OperatorProxy &op) {
@@ -240,11 +240,11 @@ bool DeleteRelaxationIFConstraints::update_constraints(
 }
 
 class DeleteRelaxationIFConstraintsFeature
-    : public plugins::TypedFeature<
-          ConstraintGenerator, DeleteRelaxationIFConstraints> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentConstraintGenerator> {
 public:
     DeleteRelaxationIFConstraintsFeature()
-        : TypedFeature("delete_relaxation_if_constraints") {
+        : TaskIndependentFeature("delete_relaxation_if_constraints") {
         document_title("Delete relaxation constraints from Imai and Fukunaga");
         document_synopsis(
             "Operator-counting constraints based on the delete relaxation. By "
@@ -292,9 +292,9 @@ public:
             "option {{{delete_relaxation_rr_constraints}}}.\n");
     }
 
-    virtual shared_ptr<DeleteRelaxationIFConstraints> create_component(
+    virtual shared_ptr<TaskIndependentConstraintGenerator> create_component(
         const plugins::Options &opts) const override {
-        return make_shared<DeleteRelaxationIFConstraints>(
+        return components::make_auto_task_independent_component<DeleteRelaxationIFConstraints, ConstraintGenerator>(
             opts.get<bool>("use_time_vars"),
             opts.get<bool>("use_integer_vars"));
     }

--- a/src/search/operator_counting/delete_relaxation_if_constraints.h
+++ b/src/search/operator_counting/delete_relaxation_if_constraints.h
@@ -63,8 +63,8 @@ class DeleteRelaxationIFConstraints : public ConstraintGenerator {
         const TaskProxy &task_proxy, LPVariables &variables);
     void create_constraints(const TaskProxy &task_proxy, lp::LinearProgram &lp);
 public:
-    explicit DeleteRelaxationIFConstraints(
-        bool use_time_vars, bool use_integer_vars);
+    DeleteRelaxationIFConstraints(
+        const std::shared_ptr<AbstractTask> &task, bool use_time_vars, bool use_integer_vars);
 
     virtual void initialize_constraints(
         const std::shared_ptr<AbstractTask> &task,

--- a/src/search/operator_counting/delete_relaxation_rr_constraints.cc
+++ b/src/search/operator_counting/delete_relaxation_rr_constraints.cc
@@ -187,9 +187,11 @@ int DeleteRelaxationRRConstraints::LPVariableIDs::id_of_t(FactPair f) const {
 }
 
 DeleteRelaxationRRConstraints::DeleteRelaxationRRConstraints(
-    const plugins::Options &opts)
-    : acyclicity_type(opts.get<AcyclicityType>("acyclicity_type")),
-      use_integer_vars(opts.get<bool>("use_integer_vars")) {
+    const shared_ptr<AbstractTask> &task, AcyclicityType acyclicity_type,
+    bool use_integer_vars)
+    : ConstraintGenerator(task),
+      acyclicity_type(acyclicity_type),
+      use_integer_vars(use_integer_vars) {
 }
 
 int DeleteRelaxationRRConstraints::get_constraint_id(FactPair f) const {
@@ -556,21 +558,19 @@ bool DeleteRelaxationRRConstraints::update_constraints(
 }
 
 class DeleteRelaxationRRConstraintsFeature
-    : public plugins::TypedFeature<
-          ConstraintGenerator, DeleteRelaxationRRConstraints> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentConstraintGenerator> {
 public:
     DeleteRelaxationRRConstraintsFeature()
-        : TypedFeature("delete_relaxation_rr_constraints") {
+        : TaskIndependentFeature("delete_relaxation_rr_constraints") {
         document_title(
             "Delete relaxation constraints from Rankooh and Rintanen");
         document_synopsis(
             "Operator-counting constraints based on the delete relaxation. By "
             "default the constraints encode an easy-to-compute relaxation of "
-            "h^+^. "
-            "With the right settings, these constraints can be used to compute "
-            "the "
-            "optimal delete-relaxation heuristic h^+^ (see example below). "
-            "For details, see" +
+            "h^+^. With the right settings, these constraints can be used to "
+            "compute the optimal delete-relaxation heuristic h^+^ (see example "
+            "below). For details, see" +
             utils::format_journal_reference(
                 {"Masood Feyzbakhsh Rankooh", "Jussi Rintanen"},
                 "Efficient Computation and Informative Estimation of "
@@ -617,6 +617,14 @@ public:
             "recommend using this formulation as it can generally be solved "
             "more efficiently, in particular in case of the h^+^ "
             "configuration, and some relaxations offer tighter bounds.\n");
+    }
+
+    virtual shared_ptr<TaskIndependentConstraintGenerator> create_component(
+        const plugins::Options &opts) const override {
+        return components::make_auto_task_independent_component<
+            DeleteRelaxationRRConstraints, ConstraintGenerator>(
+            opts.get<AcyclicityType>("acyclicity_type"),
+            opts.get<bool>("use_integer_vars"));
     }
 };
 

--- a/src/search/operator_counting/delete_relaxation_rr_constraints.h
+++ b/src/search/operator_counting/delete_relaxation_rr_constraints.h
@@ -105,7 +105,9 @@ class DeleteRelaxationRRConstraints : public ConstraintGenerator {
         const TaskProxy &task_proxy, const LPVariableIDs &lp_var_ids,
         lp::LinearProgram &lp);
 public:
-    explicit DeleteRelaxationRRConstraints(const plugins::Options &opts);
+    DeleteRelaxationRRConstraints(
+        const std::shared_ptr<AbstractTask> &task,
+        AcyclicityType acyclicity_type, bool use_integer_vars);
 
     virtual void initialize_constraints(
         const std::shared_ptr<AbstractTask> &task,

--- a/src/search/operator_counting/lm_cut_constraints.cc
+++ b/src/search/operator_counting/lm_cut_constraints.cc
@@ -11,6 +11,10 @@
 using namespace std;
 
 namespace operator_counting {
+LMCutConstraints::LMCutConstraints(const shared_ptr<AbstractTask> &task)
+    : ConstraintGenerator(task) {
+}
+
 void LMCutConstraints::initialize_constraints(
     const shared_ptr<AbstractTask> &task, lp::LinearProgram &) {
     TaskProxy task_proxy(*task);
@@ -42,9 +46,9 @@ bool LMCutConstraints::update_constraints(
 }
 
 class LMCutConstraintsFeature
-    : public plugins::TypedFeature<ConstraintGenerator, LMCutConstraints> {
+    : public plugins::TaskIndependentFeature<TaskIndependentConstraintGenerator> {
 public:
-    LMCutConstraintsFeature() : TypedFeature("lmcut_constraints") {
+    LMCutConstraintsFeature() : TaskIndependentFeature("lmcut_constraints") {
         document_title("LM-cut landmark constraints");
         document_synopsis(
             "Computes a set of landmarks in each state using the LM-cut method. "
@@ -70,9 +74,9 @@ public:
                 "2268-2274", "AAAI Press", "2013"));
     }
 
-    virtual shared_ptr<LMCutConstraints> create_component(
+    virtual shared_ptr<TaskIndependentConstraintGenerator> create_component(
         const plugins::Options &) const override {
-        return make_shared<LMCutConstraints>();
+        return components::make_auto_task_independent_component<LMCutConstraints, ConstraintGenerator>();
     }
 };
 

--- a/src/search/operator_counting/lm_cut_constraints.h
+++ b/src/search/operator_counting/lm_cut_constraints.h
@@ -13,6 +13,7 @@ namespace operator_counting {
 class LMCutConstraints : public ConstraintGenerator {
     std::unique_ptr<lm_cut_heuristic::LandmarkCutLandmarks> landmark_generator;
 public:
+    explicit LMCutConstraints(const std::shared_ptr<AbstractTask> &task);
     virtual void initialize_constraints(
         const std::shared_ptr<AbstractTask> &task,
         lp::LinearProgram &lp) override;

--- a/src/search/operator_counting/operator_counting_heuristic.cc
+++ b/src/search/operator_counting/operator_counting_heuristic.cc
@@ -13,11 +13,12 @@ using namespace std;
 
 namespace operator_counting {
 OperatorCountingHeuristic::OperatorCountingHeuristic(
+    const shared_ptr<AbstractTask> &task,
     const vector<shared_ptr<ConstraintGenerator>> &constraint_generators,
     bool use_integer_operator_counts, lp::LPSolverType lpsolver,
-    const shared_ptr<AbstractTask> &transform, bool cache_estimates,
+    bool cache_estimates,
     const string &description, utils::Verbosity verbosity)
-    : Heuristic(transform, cache_estimates, description, verbosity),
+    : Heuristic(task, cache_estimates, description, verbosity),
       constraint_generators(constraint_generators),
       lp_solver(lpsolver) {
     utils::verify_list_not_empty(
@@ -65,9 +66,9 @@ int OperatorCountingHeuristic::compute_heuristic(const State &ancestor_state) {
 }
 
 class OperatorCountingHeuristicFeature
-    : public plugins::TypedFeature<Evaluator, OperatorCountingHeuristic> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    OperatorCountingHeuristicFeature() : TypedFeature("operatorcounting") {
+    OperatorCountingHeuristicFeature() : TaskIndependentFeature("operatorcounting") {
         document_title("Operator-counting heuristic");
         document_synopsis(
             "An operator-counting heuristic computes a linear program (LP) in each "
@@ -87,7 +88,7 @@ public:
                 " on Automated Planning and Scheduling (ICAPS 2014)",
                 "226-234", "AAAI Press", "2014"));
 
-        add_list_option<shared_ptr<ConstraintGenerator>>(
+        add_list_option<shared_ptr<TaskIndependentConstraintGenerator>>(
             "constraint_generators",
             "methods that generate constraints over operator-counting variables");
         add_option<bool>(
@@ -120,10 +121,10 @@ public:
         document_property("preferred operators", "no");
     }
 
-    virtual shared_ptr<OperatorCountingHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<OperatorCountingHeuristic>(
-            opts.get_list<shared_ptr<ConstraintGenerator>>(
+        return components::make_auto_task_independent_component<OperatorCountingHeuristic, Evaluator>(
+            opts.get_list<shared_ptr<TaskIndependentConstraintGenerator>>(
                 "constraint_generators"),
             opts.get<bool>("use_integer_operator_counts"),
             lp::get_lp_solver_arguments_from_options(opts),

--- a/src/search/operator_counting/operator_counting_heuristic.h
+++ b/src/search/operator_counting/operator_counting_heuristic.h
@@ -22,10 +22,11 @@ protected:
     virtual int compute_heuristic(const State &ancestor_state) override;
 public:
     OperatorCountingHeuristic(
+        const std::shared_ptr<AbstractTask> &task,
         const std::vector<std::shared_ptr<ConstraintGenerator>>
             &constraint_generators,
         bool use_integer_operator_counts, lp::LPSolverType lpsolver,
-        const std::shared_ptr<AbstractTask> &transform, bool cache_estimates,
+        bool cache_estimates,
         const std::string &description, utils::Verbosity verbosity);
 };
 }

--- a/src/search/operator_counting/pho_constraints.cc
+++ b/src/search/operator_counting/pho_constraints.cc
@@ -16,8 +16,9 @@ using namespace std;
 
 namespace operator_counting {
 PhOConstraints::PhOConstraints(
+    const shared_ptr<AbstractTask> &task,
     const shared_ptr<pdbs::PatternCollectionGenerator> &patterns)
-    : pattern_generator(patterns) {
+    : ConstraintGenerator(task), pattern_generator(patterns) {
 }
 
 void PhOConstraints::initialize_constraints(
@@ -64,9 +65,9 @@ bool PhOConstraints::update_constraints(
 }
 
 class PhOConstraintsFeature
-    : public plugins::TypedFeature<ConstraintGenerator, PhOConstraints> {
+    : public plugins::TaskIndependentFeature<TaskIndependentConstraintGenerator> {
 public:
-    PhOConstraintsFeature() : TypedFeature("pho_constraints") {
+    PhOConstraintsFeature() : TaskIndependentFeature("pho_constraints") {
         document_title("Posthoc optimization constraints");
         document_synopsis(
             "The generator will compute a PDB for each pattern and add the"
@@ -80,14 +81,14 @@ public:
                 " Conference on Artificial Intelligence (IJCAI 2013)",
                 "2357-2364", "AAAI Press", "2013"));
 
-        add_option<shared_ptr<pdbs::PatternCollectionGenerator>>(
+        add_option<shared_ptr<pdbs::TaskIndependentPatternCollectionGenerator>>(
             "patterns", "pattern generation method", "systematic(2)");
     }
 
-    virtual shared_ptr<PhOConstraints> create_component(
+    virtual shared_ptr<TaskIndependentConstraintGenerator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<PhOConstraints>(
-            opts.get<shared_ptr<pdbs::PatternCollectionGenerator>>("patterns"));
+        return components::make_auto_task_independent_component<PhOConstraints, ConstraintGenerator>(
+            opts.get<shared_ptr<pdbs::TaskIndependentPatternCollectionGenerator>>("patterns"));
     }
 };
 

--- a/src/search/operator_counting/pho_constraints.h
+++ b/src/search/operator_counting/pho_constraints.h
@@ -24,6 +24,7 @@ class PhOConstraints : public ConstraintGenerator {
     std::shared_ptr<pdbs::PDBCollection> pdbs;
 public:
     explicit PhOConstraints(
+        const std::shared_ptr<AbstractTask> &task,
         const std::shared_ptr<pdbs::PatternCollectionGenerator> &patterns);
 
     virtual void initialize_constraints(

--- a/src/search/operator_counting/state_equation_constraints.cc
+++ b/src/search/operator_counting/state_equation_constraints.cc
@@ -11,8 +11,8 @@
 using namespace std;
 
 namespace operator_counting {
-StateEquationConstraints::StateEquationConstraints(utils::Verbosity verbosity)
-    : log(utils::get_log_for_verbosity(verbosity)) {
+StateEquationConstraints::StateEquationConstraints(const shared_ptr<AbstractTask> &task, utils::Verbosity verbosity)
+    : ConstraintGenerator(task), log(utils::get_log_for_verbosity(verbosity)) {
 }
 
 static void add_indices_to_constraint(
@@ -120,11 +120,11 @@ bool StateEquationConstraints::update_constraints(
 }
 
 class StateEquationConstraintsFeature
-    : public plugins::TypedFeature<
-          ConstraintGenerator, StateEquationConstraints> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentConstraintGenerator> {
 public:
     StateEquationConstraintsFeature()
-        : TypedFeature("state_equation_constraints") {
+        : TaskIndependentFeature("state_equation_constraints") {
         document_title("State equation constraints");
         document_synopsis(
             "For each fact, a permanent constraint is added that considers the net "
@@ -160,9 +160,9 @@ public:
         utils::add_log_options_to_feature(*this);
     }
 
-    virtual shared_ptr<StateEquationConstraints> create_component(
+    virtual shared_ptr<TaskIndependentConstraintGenerator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<StateEquationConstraints>(
+        return components::make_auto_task_independent_component<StateEquationConstraints, ConstraintGenerator>(
             utils::get_log_arguments_from_options(opts));
     }
 };

--- a/src/search/operator_counting/state_equation_constraints.h
+++ b/src/search/operator_counting/state_equation_constraints.h
@@ -42,7 +42,7 @@ class StateEquationConstraints : public ConstraintGenerator {
         named_vector::NamedVector<lp::LPConstraint> &constraints,
         double infinity);
 public:
-    explicit StateEquationConstraints(utils::Verbosity verbosity);
+    StateEquationConstraints(const std::shared_ptr<AbstractTask> &task, utils::Verbosity verbosity);
     virtual void initialize_constraints(
         const std::shared_ptr<AbstractTask> &task,
         lp::LinearProgram &lp) override;

--- a/src/search/pdbs/canonical_pdbs_heuristic.cc
+++ b/src/search/pdbs/canonical_pdbs_heuristic.cc
@@ -57,11 +57,12 @@ static CanonicalPDBs get_canonical_pdbs(
 }
 
 CanonicalPDBsHeuristic::CanonicalPDBsHeuristic(
+    const shared_ptr<AbstractTask> &task,
     const shared_ptr<PatternCollectionGenerator> &patterns,
     double max_time_dominance_pruning,
-    const shared_ptr<AbstractTask> &transform, bool cache_estimates,
+    bool cache_estimates,
     const string &description, utils::Verbosity verbosity)
-    : Heuristic(transform, cache_estimates, description, verbosity),
+    : Heuristic(task, cache_estimates, description, verbosity),
       canonical_pdbs(
           get_canonical_pdbs(task, patterns, max_time_dominance_pruning, log)) {
 }
@@ -92,9 +93,9 @@ tuple<double> get_canonical_pdbs_arguments_from_options(
 }
 
 class CanonicalPDBsHeuristicFeature
-    : public plugins::TypedFeature<Evaluator, CanonicalPDBsHeuristic> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    CanonicalPDBsHeuristicFeature() : TypedFeature("cpdbs") {
+    CanonicalPDBsHeuristicFeature() : TaskIndependentFeature("cpdbs") {
         document_subcategory("heuristics_pdb");
         document_title("Canonical PDB");
         document_synopsis(
@@ -105,7 +106,7 @@ public:
             "S in A is the sum of the heuristic values for all patterns in S "
             "for a given state.");
 
-        add_option<shared_ptr<PatternCollectionGenerator>>(
+        add_option<shared_ptr<TaskIndependentPatternCollectionGenerator>>(
             "patterns", "pattern generation method", "systematic(1)");
         add_canonical_pdbs_options_to_feature(*this);
         add_heuristic_options_to_feature(*this, "cpdbs");
@@ -120,10 +121,10 @@ public:
         document_property("preferred operators", "no");
     }
 
-    virtual shared_ptr<CanonicalPDBsHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<CanonicalPDBsHeuristic>(
-            opts.get<shared_ptr<PatternCollectionGenerator>>("patterns"),
+        return components::make_auto_task_independent_component<CanonicalPDBsHeuristic, Evaluator>(
+            opts.get<shared_ptr<TaskIndependentPatternCollectionGenerator>>("patterns"),
             get_canonical_pdbs_arguments_from_options(opts),
             get_heuristic_arguments_from_options(opts));
     }

--- a/src/search/pdbs/canonical_pdbs_heuristic.h
+++ b/src/search/pdbs/canonical_pdbs_heuristic.h
@@ -20,9 +20,10 @@ protected:
 
 public:
     CanonicalPDBsHeuristic(
+        const std::shared_ptr<AbstractTask> &task,
         const std::shared_ptr<PatternCollectionGenerator> &patterns,
         double max_time_dominance_pruning,
-        const std::shared_ptr<AbstractTask> &transform, bool cache_estimates,
+        bool cache_estimates,
         const std::string &description, utils::Verbosity verbosity);
 };
 

--- a/src/search/pdbs/pattern_collection_generator_disjoint_cegar.cc
+++ b/src/search/pdbs/pattern_collection_generator_disjoint_cegar.cc
@@ -12,9 +12,10 @@ using namespace std;
 namespace pdbs {
 PatternCollectionGeneratorDisjointCegar::
     PatternCollectionGeneratorDisjointCegar(
+        const shared_ptr<AbstractTask> &task,
         int max_pdb_size, int max_collection_size, double max_time,
         bool use_wildcard_plans, int random_seed, utils::Verbosity verbosity)
-    : PatternCollectionGenerator(verbosity),
+    : PatternCollectionGenerator(task, verbosity),
       max_pdb_size(max_pdb_size),
       max_collection_size(max_collection_size),
       max_time(max_time),
@@ -39,11 +40,11 @@ PatternCollectionGeneratorDisjointCegar::compute_patterns(
 }
 
 class PatternCollectionGeneratorDisjointCegarFeature
-    : public plugins::TypedFeature<
-          PatternCollectionGenerator, PatternCollectionGeneratorDisjointCegar> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentPatternCollectionGenerator> {
 public:
     PatternCollectionGeneratorDisjointCegarFeature()
-        : TypedFeature("disjoint_cegar") {
+        : TaskIndependentFeature("disjoint_cegar") {
         document_title("Disjoint CEGAR");
         document_synopsis(
             "This pattern collection generator uses the CEGAR algorithm to "
@@ -79,10 +80,10 @@ public:
         add_cegar_implementation_notes_to_feature(*this);
     }
 
-    virtual shared_ptr<PatternCollectionGeneratorDisjointCegar>
+    virtual shared_ptr<TaskIndependentPatternCollectionGenerator>
     create_component(const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<
-            PatternCollectionGeneratorDisjointCegar>(
+        return components::make_auto_task_independent_component<
+            PatternCollectionGeneratorDisjointCegar, PatternCollectionGenerator>(
             opts.get<int>("max_pdb_size"), opts.get<int>("max_collection_size"),
             opts.get<double>("max_time"),
             get_cegar_wildcard_arguments_from_options(opts),

--- a/src/search/pdbs/pattern_collection_generator_disjoint_cegar.h
+++ b/src/search/pdbs/pattern_collection_generator_disjoint_cegar.h
@@ -25,6 +25,7 @@ class PatternCollectionGeneratorDisjointCegar
         const std::shared_ptr<AbstractTask> &task) override;
 public:
     PatternCollectionGeneratorDisjointCegar(
+        const std::shared_ptr<AbstractTask> &task,
         int max_pdb_size, int max_collection_size, double max_time,
         bool use_wildcard_plans, int random_seed, utils::Verbosity verbosity);
 };

--- a/src/search/pdbs/pattern_collection_generator_genetic.cc
+++ b/src/search/pdbs/pattern_collection_generator_genetic.cc
@@ -25,10 +25,11 @@ using namespace std;
 
 namespace pdbs {
 PatternCollectionGeneratorGenetic::PatternCollectionGeneratorGenetic(
+    const shared_ptr<AbstractTask> &task,
     int pdb_max_size, int num_collections, int num_episodes,
     double mutation_probability, bool disjoint, int random_seed,
     utils::Verbosity verbosity)
-    : PatternCollectionGenerator(verbosity),
+    : PatternCollectionGenerator(task, verbosity),
       pdb_max_size(pdb_max_size),
       num_collections(num_collections),
       num_episodes(num_episodes),
@@ -304,10 +305,10 @@ PatternCollectionGeneratorGenetic::compute_patterns(
 }
 
 class PatternCollectionGeneratorGeneticFeature
-    : public plugins::TypedFeature<
-          PatternCollectionGenerator, PatternCollectionGeneratorGenetic> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentPatternCollectionGenerator> {
 public:
-    PatternCollectionGeneratorGeneticFeature() : TypedFeature("genetic") {
+    PatternCollectionGeneratorGeneticFeature() : TaskIndependentFeature("genetic") {
         document_title("Genetic algorithm patterns");
         document_synopsis(
             "The following paper describes the automated creation of pattern "
@@ -388,10 +389,10 @@ public:
         document_language_support("axioms", "not supported");
     }
 
-    virtual shared_ptr<PatternCollectionGeneratorGenetic> create_component(
+    virtual shared_ptr<TaskIndependentPatternCollectionGenerator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<
-            PatternCollectionGeneratorGenetic>(
+        return components::make_auto_task_independent_component<
+            PatternCollectionGeneratorGenetic, PatternCollectionGenerator>(
             opts.get<int>("pdb_max_size"), opts.get<int>("num_collections"),
             opts.get<int>("num_episodes"),
             opts.get<double>("mutation_probability"),

--- a/src/search/pdbs/pattern_collection_generator_genetic.h
+++ b/src/search/pdbs/pattern_collection_generator_genetic.h
@@ -114,6 +114,7 @@ class PatternCollectionGeneratorGenetic : public PatternCollectionGenerator {
         const std::shared_ptr<AbstractTask> &task) override;
 public:
     PatternCollectionGeneratorGenetic(
+        const std::shared_ptr<AbstractTask> &task,
         int pdb_max_size, int num_collections, int num_episodes,
         double mutation_probability, bool disjoint, int random_seed,
         utils::Verbosity verbosity);

--- a/src/search/pdbs/pattern_collection_generator_hillclimbing.cc
+++ b/src/search/pdbs/pattern_collection_generator_hillclimbing.cc
@@ -115,10 +115,11 @@ static vector<vector<int>> compute_relevant_neighbours(
 }
 
 PatternCollectionGeneratorHillclimbing::PatternCollectionGeneratorHillclimbing(
+    const shared_ptr<AbstractTask> &task,
     int pdb_max_size, int collection_max_size, int num_samples,
     int min_improvement, double max_time, int random_seed,
     utils::Verbosity verbosity)
-    : PatternCollectionGenerator(verbosity),
+    : PatternCollectionGenerator(task, verbosity),
       pdb_max_size(pdb_max_size),
       collection_max_size(collection_max_size),
       num_samples(num_samples),
@@ -582,11 +583,11 @@ static basic_string<char> paper_references() {
 }
 
 class PatternCollectionGeneratorHillclimbingFeature
-    : public plugins::TypedFeature<
-          PatternCollectionGenerator, PatternCollectionGeneratorHillclimbing> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentPatternCollectionGenerator> {
 public:
     PatternCollectionGeneratorHillclimbingFeature()
-        : TypedFeature("hillclimbing") {
+        : TaskIndependentFeature("hillclimbing") {
         document_title("Hill climbing");
         document_synopsis(
             "This algorithm uses hill climbing to generate patterns "
@@ -597,10 +598,10 @@ public:
         add_generator_options_to_feature(*this);
     }
 
-    virtual shared_ptr<PatternCollectionGeneratorHillclimbing> create_component(
+    virtual shared_ptr<TaskIndependentPatternCollectionGenerator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<
-            PatternCollectionGeneratorHillclimbing>(
+        return components::make_auto_task_independent_component<
+            PatternCollectionGeneratorHillclimbing, PatternCollectionGenerator>(
             get_hillclimbing_arguments_from_options(opts),
             get_generator_arguments_from_options(opts));
     }
@@ -610,9 +611,9 @@ static plugins::FeaturePlugin<PatternCollectionGeneratorHillclimbingFeature>
     _plugin;
 
 class IPDBFeature
-    : public plugins::TypedFeature<Evaluator, CanonicalPDBsHeuristic> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    IPDBFeature() : TypedFeature("ipdb") {
+    IPDBFeature() : TaskIndependentFeature("ipdb") {
         document_subcategory("heuristics_pdb");
         document_title("iPDB");
         document_synopsis(
@@ -649,15 +650,15 @@ public:
         document_property("preferred operators", "no");
     }
 
-    virtual shared_ptr<CanonicalPDBsHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        shared_ptr<PatternCollectionGeneratorHillclimbing> pgh =
-            plugins::make_shared_from_arg_tuples<
-                PatternCollectionGeneratorHillclimbing>(
+        shared_ptr<TaskIndependentPatternCollectionGenerator> pgh =
+            components::make_auto_task_independent_component<
+                PatternCollectionGeneratorHillclimbing, PatternCollectionGenerator>(
                 get_hillclimbing_arguments_from_options(opts),
                 get_generator_arguments_from_options(opts));
 
-        return plugins::make_shared_from_arg_tuples<CanonicalPDBsHeuristic>(
+        return components::make_auto_task_independent_component<CanonicalPDBsHeuristic, Evaluator>(
             pgh, opts.get<double>("max_time_dominance_pruning"),
             get_heuristic_arguments_from_options(opts));
     }

--- a/src/search/pdbs/pattern_collection_generator_hillclimbing.h
+++ b/src/search/pdbs/pattern_collection_generator_hillclimbing.h
@@ -130,6 +130,7 @@ class PatternCollectionGeneratorHillclimbing
         const std::shared_ptr<AbstractTask> &task) override;
 public:
     PatternCollectionGeneratorHillclimbing(
+        const std::shared_ptr<AbstractTask> &task,
         int pdb_max_size, int collection_max_size, int num_samples,
         int min_improvement, double max_time, int random_seed,
         utils::Verbosity verbosity);

--- a/src/search/pdbs/pattern_collection_generator_manual.cc
+++ b/src/search/pdbs/pattern_collection_generator_manual.cc
@@ -13,8 +13,9 @@ using namespace std;
 
 namespace pdbs {
 PatternCollectionGeneratorManual::PatternCollectionGeneratorManual(
+    const shared_ptr<AbstractTask> &task,
     const vector<Pattern> &patterns, utils::Verbosity verbosity)
-    : PatternCollectionGenerator(verbosity),
+    : PatternCollectionGenerator(task, verbosity),
       patterns(make_shared<PatternCollection>(patterns)) {
 }
 
@@ -32,11 +33,11 @@ PatternCollectionInformation PatternCollectionGeneratorManual::compute_patterns(
 }
 
 class PatternCollectionGeneratorManualFeature
-    : public plugins::TypedFeature<
-          PatternCollectionGenerator, PatternCollectionGeneratorManual> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentPatternCollectionGenerator> {
 public:
     PatternCollectionGeneratorManualFeature()
-        : TypedFeature("manual_patterns") {
+        : TaskIndependentFeature("manual_patterns") {
         document_title("Manual patterns");
         add_list_option<Pattern>(
             "patterns",
@@ -45,10 +46,10 @@ public:
         add_generator_options_to_feature(*this);
     }
 
-    virtual shared_ptr<PatternCollectionGeneratorManual> create_component(
+    virtual shared_ptr<TaskIndependentPatternCollectionGenerator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<
-            PatternCollectionGeneratorManual>(
+        return components::make_auto_task_independent_component<
+            PatternCollectionGeneratorManual, PatternCollectionGenerator>(
             opts.get_list<Pattern>("patterns"),
             get_generator_arguments_from_options(opts));
     }

--- a/src/search/pdbs/pattern_collection_generator_manual.h
+++ b/src/search/pdbs/pattern_collection_generator_manual.h
@@ -15,6 +15,7 @@ class PatternCollectionGeneratorManual : public PatternCollectionGenerator {
         const std::shared_ptr<AbstractTask> &task) override;
 public:
     explicit PatternCollectionGeneratorManual(
+        const std::shared_ptr<AbstractTask> &task,
         const std::vector<Pattern> &patterns, utils::Verbosity verbosity);
 };
 }

--- a/src/search/pdbs/pattern_collection_generator_multiple.cc
+++ b/src/search/pdbs/pattern_collection_generator_multiple.cc
@@ -16,12 +16,13 @@ using namespace std;
 
 namespace pdbs {
 PatternCollectionGeneratorMultiple::PatternCollectionGeneratorMultiple(
+    const shared_ptr<AbstractTask> &task,
     int max_pdb_size, int max_collection_size,
     double pattern_generation_max_time, double total_max_time,
     double stagnation_limit, double blacklist_trigger_percentage,
     bool enable_blacklist_on_stagnation, int random_seed,
     utils::Verbosity verbosity)
-    : PatternCollectionGenerator(verbosity),
+    : PatternCollectionGenerator(task, verbosity),
       max_pdb_size(max_pdb_size),
       pattern_generation_max_time(pattern_generation_max_time),
       total_max_time(total_max_time),

--- a/src/search/pdbs/pattern_collection_generator_multiple.h
+++ b/src/search/pdbs/pattern_collection_generator_multiple.h
@@ -71,6 +71,7 @@ class PatternCollectionGeneratorMultiple : public PatternCollectionGenerator {
         const std::shared_ptr<AbstractTask> &task) override;
 public:
     PatternCollectionGeneratorMultiple(
+        const std::shared_ptr<AbstractTask> &task,
         int max_pdb_size, int max_collection_size,
         double pattern_generation_max_time, double total_max_time,
         double stagnation_limit, double blacklist_trigger_percentage,

--- a/src/search/pdbs/pattern_collection_generator_multiple_cegar.cc
+++ b/src/search/pdbs/pattern_collection_generator_multiple_cegar.cc
@@ -12,13 +12,14 @@ using namespace std;
 namespace pdbs {
 PatternCollectionGeneratorMultipleCegar::
     PatternCollectionGeneratorMultipleCegar(
+        const shared_ptr<AbstractTask> &task,
         bool use_wildcard_plans, int max_pdb_size, int max_collection_size,
         double pattern_generation_max_time, double total_max_time,
         double stagnation_limit, double blacklist_trigger_percentage,
         bool enable_blacklist_on_stagnation, int random_seed,
         utils::Verbosity verbosity)
     : PatternCollectionGeneratorMultiple(
-          max_pdb_size, max_collection_size, pattern_generation_max_time,
+          task, max_pdb_size, max_collection_size, pattern_generation_max_time,
           total_max_time, stagnation_limit, blacklist_trigger_percentage,
           enable_blacklist_on_stagnation, random_seed, verbosity),
       use_wildcard_plans(use_wildcard_plans) {
@@ -40,11 +41,11 @@ PatternInformation PatternCollectionGeneratorMultipleCegar::compute_pattern(
 }
 
 class PatternCollectionGeneratorMultipleCegarFeature
-    : public plugins::TypedFeature<
-          PatternCollectionGenerator, PatternCollectionGeneratorMultipleCegar> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentPatternCollectionGenerator> {
 public:
     PatternCollectionGeneratorMultipleCegarFeature()
-        : TypedFeature("multiple_cegar") {
+        : TaskIndependentFeature("multiple_cegar") {
         document_title("Multiple CEGAR");
         document_synopsis(
             "This pattern collection generator implements the multiple CEGAR "
@@ -62,10 +63,10 @@ public:
         add_multiple_algorithm_implementation_notes_to_feature(*this);
     }
 
-    virtual shared_ptr<PatternCollectionGeneratorMultipleCegar>
+    virtual shared_ptr<TaskIndependentPatternCollectionGenerator>
     create_component(const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<
-            PatternCollectionGeneratorMultipleCegar>(
+        return components::make_auto_task_independent_component<
+            PatternCollectionGeneratorMultipleCegar, PatternCollectionGenerator>(
             get_cegar_wildcard_arguments_from_options(opts),
             get_multiple_arguments_from_options(opts));
     }

--- a/src/search/pdbs/pattern_collection_generator_multiple_cegar.h
+++ b/src/search/pdbs/pattern_collection_generator_multiple_cegar.h
@@ -18,6 +18,7 @@ class PatternCollectionGeneratorMultipleCegar
         std::unordered_set<int> &&blacklisted_variables) override;
 public:
     PatternCollectionGeneratorMultipleCegar(
+        const std::shared_ptr<AbstractTask> &task,
         bool use_wildcard_plans, int max_pdb_size, int max_collection_size,
         double pattern_generation_max_time, double total_max_time,
         double stagnation_limit, double blacklist_trigger_percentage,

--- a/src/search/pdbs/pattern_collection_generator_multiple_random.cc
+++ b/src/search/pdbs/pattern_collection_generator_multiple_random.cc
@@ -15,13 +15,14 @@ using namespace std;
 namespace pdbs {
 PatternCollectionGeneratorMultipleRandom::
     PatternCollectionGeneratorMultipleRandom(
+        const shared_ptr<AbstractTask> &task,
         bool bidirectional, int max_pdb_size, int max_collection_size,
         double pattern_generation_max_time, double total_max_time,
         double stagnation_limit, double blacklist_trigger_percentage,
         bool enable_blacklist_on_stagnation, int random_seed,
         utils::Verbosity verbosity)
     : PatternCollectionGeneratorMultiple(
-          max_pdb_size, max_collection_size, pattern_generation_max_time,
+          task, max_pdb_size, max_collection_size, pattern_generation_max_time,
           total_max_time, stagnation_limit, blacklist_trigger_percentage,
           enable_blacklist_on_stagnation, random_seed, verbosity),
       bidirectional(bidirectional) {
@@ -53,12 +54,11 @@ PatternInformation PatternCollectionGeneratorMultipleRandom::compute_pattern(
 }
 
 class PatternCollectionGeneratorMultipleRandomFeature
-    : public plugins::TypedFeature<
-          PatternCollectionGenerator,
-          PatternCollectionGeneratorMultipleRandom> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentPatternCollectionGenerator> {
 public:
     PatternCollectionGeneratorMultipleRandomFeature()
-        : TypedFeature("random_patterns") {
+        : TaskIndependentFeature("random_patterns") {
         document_title("Multiple random patterns");
         document_synopsis(
             "This pattern collection generator implements the 'multiple "
@@ -77,10 +77,10 @@ public:
         add_multiple_algorithm_implementation_notes_to_feature(*this);
     }
 
-    virtual shared_ptr<PatternCollectionGeneratorMultipleRandom>
+    virtual shared_ptr<TaskIndependentPatternCollectionGenerator>
     create_component(const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<
-            PatternCollectionGeneratorMultipleRandom>(
+        return components::make_auto_task_independent_component<
+            PatternCollectionGeneratorMultipleRandom, PatternCollectionGenerator>(
             get_random_pattern_bidirectional_arguments_from_options(opts),
             get_multiple_arguments_from_options(opts));
     }

--- a/src/search/pdbs/pattern_collection_generator_multiple_random.h
+++ b/src/search/pdbs/pattern_collection_generator_multiple_random.h
@@ -18,6 +18,7 @@ class PatternCollectionGeneratorMultipleRandom
         std::unordered_set<int> &&blacklisted_variables) override;
 public:
     PatternCollectionGeneratorMultipleRandom(
+        const std::shared_ptr<AbstractTask> &task,
         bool bidirectional, int max_pdb_size, int max_collection_size,
         double pattern_generation_max_time, double total_max_time,
         double stagnation_limit, double blacklist_trigger_percentage,

--- a/src/search/pdbs/pattern_collection_generator_systematic.cc
+++ b/src/search/pdbs/pattern_collection_generator_systematic.cc
@@ -46,9 +46,10 @@ static void compute_union_pattern(
 }
 
 PatternCollectionGeneratorSystematic::PatternCollectionGeneratorSystematic(
+    const shared_ptr<AbstractTask> &task,
     int pattern_max_size, bool only_interesting_patterns,
     utils::Verbosity verbosity)
-    : PatternCollectionGenerator(verbosity),
+    : PatternCollectionGenerator(task, verbosity),
       max_pattern_size(pattern_max_size),
       only_interesting_patterns(only_interesting_patterns) {
 }
@@ -289,10 +290,10 @@ PatternCollectionGeneratorSystematic::compute_patterns(
 }
 
 class PatternCollectionGeneratorSystematicFeature
-    : public plugins::TypedFeature<
-          PatternCollectionGenerator, PatternCollectionGeneratorSystematic> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentPatternCollectionGenerator> {
 public:
-    PatternCollectionGeneratorSystematicFeature() : TypedFeature("systematic") {
+    PatternCollectionGeneratorSystematicFeature() : TaskIndependentFeature("systematic") {
         document_title("Systematically generated patterns");
         document_synopsis(
             "Generates all (interesting) patterns with up to pattern_max_size "
@@ -317,10 +318,10 @@ public:
         add_generator_options_to_feature(*this);
     }
 
-    virtual shared_ptr<PatternCollectionGeneratorSystematic> create_component(
+    virtual shared_ptr<TaskIndependentPatternCollectionGenerator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<
-            PatternCollectionGeneratorSystematic>(
+        return components::make_auto_task_independent_component<
+            PatternCollectionGeneratorSystematic, PatternCollectionGenerator>(
             opts.get<int>("pattern_max_size"),
             opts.get<bool>("only_interesting_patterns"),
             get_generator_arguments_from_options(opts));

--- a/src/search/pdbs/pattern_collection_generator_systematic.h
+++ b/src/search/pdbs/pattern_collection_generator_systematic.h
@@ -46,6 +46,7 @@ class PatternCollectionGeneratorSystematic : public PatternCollectionGenerator {
         const std::shared_ptr<AbstractTask> &task) override;
 public:
     PatternCollectionGeneratorSystematic(
+        const std::shared_ptr<AbstractTask> &task,
         int pattern_max_size, bool only_interesting_patterns,
         utils::Verbosity verbosity);
 };

--- a/src/search/pdbs/pattern_generator.cc
+++ b/src/search/pdbs/pattern_generator.cc
@@ -8,8 +8,8 @@ using namespace std;
 
 namespace pdbs {
 PatternCollectionGenerator::PatternCollectionGenerator(
-    utils::Verbosity verbosity)
-    : log(utils::get_log_for_verbosity(verbosity)) {
+    const shared_ptr<AbstractTask> &task, utils::Verbosity verbosity)
+    : components::TaskSpecificComponent(task), log(utils::get_log_for_verbosity(verbosity)) {
 }
 
 PatternCollectionInformation PatternCollectionGenerator::generate(
@@ -23,8 +23,8 @@ PatternCollectionInformation PatternCollectionGenerator::generate(
     return pci;
 }
 
-PatternGenerator::PatternGenerator(utils::Verbosity verbosity)
-    : log(utils::get_log_for_verbosity(verbosity)) {
+PatternGenerator::PatternGenerator(const shared_ptr<AbstractTask> &task, utils::Verbosity verbosity)
+    : components::TaskSpecificComponent(task), log(utils::get_log_for_verbosity(verbosity)) {
 }
 
 PatternInformation PatternGenerator::generate(
@@ -48,7 +48,7 @@ tuple<utils::Verbosity> get_generator_arguments_from_options(
 }
 
 static class PatternCollectionGeneratorCategoryPlugin
-    : public plugins::TypedCategoryPlugin<PatternCollectionGenerator> {
+    : public plugins::TypedCategoryPlugin<TaskIndependentPatternCollectionGenerator> {
 public:
     PatternCollectionGeneratorCategoryPlugin()
         : TypedCategoryPlugin("PatternCollectionGenerator") {
@@ -58,7 +58,7 @@ public:
 } _category_plugin_collection;
 
 static class PatternGeneratorCategoryPlugin
-    : public plugins::TypedCategoryPlugin<PatternGenerator> {
+    : public plugins::TypedCategoryPlugin<TaskIndependentPatternGenerator> {
 public:
     PatternGeneratorCategoryPlugin() : TypedCategoryPlugin("PatternGenerator") {
         document_synopsis(

--- a/src/search/pdbs/pattern_generator.h
+++ b/src/search/pdbs/pattern_generator.h
@@ -5,6 +5,8 @@
 #include "pattern_information.h"
 #include "types.h"
 
+#include "../component.h"
+
 #include "../utils/logging.h"
 
 #include <memory>
@@ -22,32 +24,36 @@ class RandomNumberGenerator;
 }
 
 namespace pdbs {
-class PatternCollectionGenerator {
+class PatternCollectionGenerator : public components::TaskSpecificComponent {
     virtual std::string name() const = 0;
     virtual PatternCollectionInformation compute_patterns(
         const std::shared_ptr<AbstractTask> &task) = 0;
 protected:
     mutable utils::LogProxy log;
 public:
-    explicit PatternCollectionGenerator(utils::Verbosity verbosity);
-    virtual ~PatternCollectionGenerator() = default;
+    PatternCollectionGenerator(const std::shared_ptr<AbstractTask> &task, utils::Verbosity verbosity);
 
     PatternCollectionInformation generate(
         const std::shared_ptr<AbstractTask> &task);
 };
 
-class PatternGenerator {
+using TaskIndependentPatternCollectionGenerator =
+    components::TaskIndependentComponent<PatternCollectionGenerator>;
+
+class PatternGenerator : public components::TaskSpecificComponent {
     virtual std::string name() const = 0;
     virtual PatternInformation compute_pattern(
         const std::shared_ptr<AbstractTask> &task) = 0;
 protected:
     mutable utils::LogProxy log;
 public:
-    explicit PatternGenerator(utils::Verbosity verbosity);
-    virtual ~PatternGenerator() = default;
+    PatternGenerator(const std::shared_ptr<AbstractTask> &task, utils::Verbosity verbosity);
 
     PatternInformation generate(const std::shared_ptr<AbstractTask> &task);
 };
+
+using TaskIndependentPatternGenerator =
+    components::TaskIndependentComponent<PatternGenerator>;
 
 extern void add_generator_options_to_feature(plugins::Feature &feature);
 extern std::tuple<utils::Verbosity> get_generator_arguments_from_options(

--- a/src/search/pdbs/pattern_generator_cegar.cc
+++ b/src/search/pdbs/pattern_generator_cegar.cc
@@ -17,9 +17,10 @@ using namespace std;
 
 namespace pdbs {
 PatternGeneratorCEGAR::PatternGeneratorCEGAR(
+    const shared_ptr<AbstractTask> &task,
     int max_pdb_size, double max_time, bool use_wildcard_plans, int random_seed,
     utils::Verbosity verbosity)
-    : PatternGenerator(verbosity),
+    : PatternGenerator(task, verbosity),
       max_pdb_size(max_pdb_size),
       max_time(max_time),
       use_wildcard_plans(use_wildcard_plans),
@@ -39,9 +40,9 @@ PatternInformation PatternGeneratorCEGAR::compute_pattern(
 }
 
 class PatternGeneratorCEGARFeature
-    : public plugins::TypedFeature<PatternGenerator, PatternGeneratorCEGAR> {
+    : public plugins::TaskIndependentFeature<TaskIndependentPatternGenerator> {
 public:
-    PatternGeneratorCEGARFeature() : TypedFeature("cegar_pattern") {
+    PatternGeneratorCEGARFeature() : TaskIndependentFeature("cegar_pattern") {
         document_title("CEGAR");
         document_synopsis(
             "This pattern generator uses the CEGAR algorithm restricted to a "
@@ -66,9 +67,9 @@ public:
         add_cegar_implementation_notes_to_feature(*this);
     }
 
-    virtual shared_ptr<PatternGeneratorCEGAR> create_component(
+    virtual shared_ptr<TaskIndependentPatternGenerator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<PatternGeneratorCEGAR>(
+        return components::make_auto_task_independent_component<PatternGeneratorCEGAR, PatternGenerator>(
             opts.get<int>("max_pdb_size"), opts.get<double>("max_time"),
             get_cegar_wildcard_arguments_from_options(opts),
             utils::get_rng_arguments_from_options(opts),

--- a/src/search/pdbs/pattern_generator_cegar.h
+++ b/src/search/pdbs/pattern_generator_cegar.h
@@ -19,6 +19,7 @@ class PatternGeneratorCEGAR : public PatternGenerator {
         const std::shared_ptr<AbstractTask> &task) override;
 public:
     PatternGeneratorCEGAR(
+        const std::shared_ptr<AbstractTask> &task,
         int max_pdb_size, double max_time, bool use_wildcard_plans,
         int random_seed, utils::Verbosity verbosity);
 };

--- a/src/search/pdbs/pattern_generator_greedy.cc
+++ b/src/search/pdbs/pattern_generator_greedy.cc
@@ -17,8 +17,9 @@ using namespace std;
 
 namespace pdbs {
 PatternGeneratorGreedy::PatternGeneratorGreedy(
+    const shared_ptr<AbstractTask> &task,
     int max_states, utils::Verbosity verbosity)
-    : PatternGenerator(verbosity), max_states(max_states) {
+    : PatternGenerator(task, verbosity), max_states(max_states) {
 }
 
 string PatternGeneratorGreedy::name() const {
@@ -52,9 +53,9 @@ PatternInformation PatternGeneratorGreedy::compute_pattern(
 }
 
 class PatternGeneratorGreedyFeature
-    : public plugins::TypedFeature<PatternGenerator, PatternGeneratorGreedy> {
+    : public plugins::TaskIndependentFeature<TaskIndependentPatternGenerator> {
 public:
-    PatternGeneratorGreedyFeature() : TypedFeature("greedy") {
+    PatternGeneratorGreedyFeature() : TaskIndependentFeature("greedy") {
         document_title("Greedy");
         add_option<int>(
             "max_states",
@@ -63,9 +64,9 @@ public:
         add_generator_options_to_feature(*this);
     }
 
-    virtual shared_ptr<PatternGeneratorGreedy> create_component(
+    virtual shared_ptr<TaskIndependentPatternGenerator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<PatternGeneratorGreedy>(
+        return components::make_auto_task_independent_component<PatternGeneratorGreedy, PatternGenerator>(
             opts.get<int>("max_states"),
             get_generator_arguments_from_options(opts));
     }

--- a/src/search/pdbs/pattern_generator_greedy.h
+++ b/src/search/pdbs/pattern_generator_greedy.h
@@ -11,7 +11,7 @@ class PatternGeneratorGreedy : public PatternGenerator {
     virtual PatternInformation compute_pattern(
         const std::shared_ptr<AbstractTask> &task) override;
 public:
-    PatternGeneratorGreedy(int max_states, utils::Verbosity verbosity);
+    PatternGeneratorGreedy(const std::shared_ptr<AbstractTask> &task, int max_states, utils::Verbosity verbosity);
 };
 }
 

--- a/src/search/pdbs/pattern_generator_manual.cc
+++ b/src/search/pdbs/pattern_generator_manual.cc
@@ -13,8 +13,8 @@ using namespace std;
 
 namespace pdbs {
 PatternGeneratorManual::PatternGeneratorManual(
-    const vector<int> &pattern, utils::Verbosity verbosity)
-    : PatternGenerator(verbosity), pattern(pattern) {
+    const shared_ptr<AbstractTask> &task, const vector<int> &pattern, utils::Verbosity verbosity)
+    : PatternGenerator(task, verbosity), pattern(pattern) {
 }
 
 string PatternGeneratorManual::name() const {
@@ -31,9 +31,9 @@ PatternInformation PatternGeneratorManual::compute_pattern(
 }
 
 class PatternGeneratorManualFeature
-    : public plugins::TypedFeature<PatternGenerator, PatternGeneratorManual> {
+    : public plugins::TaskIndependentFeature<TaskIndependentPatternGenerator> {
 public:
-    PatternGeneratorManualFeature() : TypedFeature("manual_pattern") {
+    PatternGeneratorManualFeature() : TaskIndependentFeature("manual_pattern") {
         document_title("Manual pattern");
         add_list_option<int>(
             "pattern",
@@ -42,9 +42,9 @@ public:
         add_generator_options_to_feature(*this);
     }
 
-    virtual shared_ptr<PatternGeneratorManual> create_component(
+    virtual shared_ptr<TaskIndependentPatternGenerator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<PatternGeneratorManual>(
+        return components::make_auto_task_independent_component<PatternGeneratorManual, PatternGenerator>(
             opts.get_list<int>("pattern"),
             get_generator_arguments_from_options(opts));
     }

--- a/src/search/pdbs/pattern_generator_manual.h
+++ b/src/search/pdbs/pattern_generator_manual.h
@@ -13,6 +13,7 @@ class PatternGeneratorManual : public PatternGenerator {
         const std::shared_ptr<AbstractTask> &task) override;
 public:
     PatternGeneratorManual(
+        const std::shared_ptr<AbstractTask> &task,
         const std::vector<int> &pattern, utils::Verbosity verbosity);
 };
 }

--- a/src/search/pdbs/pattern_generator_random.cc
+++ b/src/search/pdbs/pattern_generator_random.cc
@@ -17,9 +17,10 @@ using namespace std;
 
 namespace pdbs {
 PatternGeneratorRandom::PatternGeneratorRandom(
+    const shared_ptr<AbstractTask> &task,
     int max_pdb_size, double max_time, bool bidirectional, int random_seed,
     utils::Verbosity verbosity)
-    : PatternGenerator(verbosity),
+    : PatternGenerator(task, verbosity),
       max_pdb_size(max_pdb_size),
       max_time(max_time),
       bidirectional(bidirectional),
@@ -45,9 +46,9 @@ PatternInformation PatternGeneratorRandom::compute_pattern(
 }
 
 class PatternGeneratorRandomFeature
-    : public plugins::TypedFeature<PatternGenerator, PatternGeneratorRandom> {
+    : public plugins::TaskIndependentFeature<TaskIndependentPatternGenerator> {
 public:
-    PatternGeneratorRandomFeature() : TypedFeature("random_pattern") {
+    PatternGeneratorRandomFeature() : TaskIndependentFeature("random_pattern") {
         document_title("Random pattern");
         document_synopsis(
             "This pattern generator implements the 'single randomized "
@@ -71,9 +72,9 @@ public:
         add_random_pattern_implementation_notes_to_feature(*this);
     }
 
-    virtual shared_ptr<PatternGeneratorRandom> create_component(
+    virtual shared_ptr<TaskIndependentPatternGenerator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<PatternGeneratorRandom>(
+        return components::make_auto_task_independent_component<PatternGeneratorRandom, PatternGenerator>(
             opts.get<int>("max_pdb_size"), opts.get<double>("max_time"),
             get_random_pattern_bidirectional_arguments_from_options(opts),
             utils::get_rng_arguments_from_options(opts),

--- a/src/search/pdbs/pattern_generator_random.h
+++ b/src/search/pdbs/pattern_generator_random.h
@@ -19,6 +19,7 @@ class PatternGeneratorRandom : public PatternGenerator {
         const std::shared_ptr<AbstractTask> &task) override;
 public:
     PatternGeneratorRandom(
+        const std::shared_ptr<AbstractTask> &task,
         int max_pdb_size, double max_time, bool bidirectional, int random_seed,
         utils::Verbosity verbosity);
 };

--- a/src/search/pdbs/pdb_heuristic.cc
+++ b/src/search/pdbs/pdb_heuristic.cc
@@ -19,10 +19,11 @@ static shared_ptr<PatternDatabase> get_pdb_from_generator(
 }
 
 PDBHeuristic::PDBHeuristic(
+    const shared_ptr<AbstractTask> &task,
     const shared_ptr<PatternGenerator> &pattern,
-    const shared_ptr<AbstractTask> &transform, bool cache_estimates,
+    bool cache_estimates,
     const string &description, utils::Verbosity verbosity)
-    : Heuristic(transform, cache_estimates, description, verbosity),
+    : Heuristic(task, cache_estimates, description, verbosity),
       pdb(get_pdb_from_generator(task, pattern)) {
 }
 
@@ -51,9 +52,9 @@ static basic_string<char> paper_references() {
                "105-111", "AAAI Press", "2012");
 }
 class PDBHeuristicFeature
-    : public plugins::TypedFeature<Evaluator, PDBHeuristic> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    PDBHeuristicFeature() : TypedFeature("pdb") {
+    PDBHeuristicFeature() : TaskIndependentFeature("pdb") {
         document_subcategory("heuristics_pdb");
         document_title("Pattern database heuristic");
         document_synopsis(
@@ -62,7 +63,7 @@ public:
             "First used in domain-independent planning by:" +
             paper_references());
 
-        add_option<shared_ptr<PatternGenerator>>(
+        add_option<shared_ptr<TaskIndependentPatternGenerator>>(
             "pattern", "pattern generation method", "greedy()");
         add_heuristic_options_to_feature(*this, "pdb");
 
@@ -76,10 +77,10 @@ public:
         document_property("preferred operators", "no");
     }
 
-    virtual shared_ptr<PDBHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<PDBHeuristic>(
-            opts.get<shared_ptr<PatternGenerator>>("pattern"),
+        return components::make_auto_task_independent_component<PDBHeuristic, Evaluator>(
+            opts.get<shared_ptr<TaskIndependentPatternGenerator>>("pattern"),
             get_heuristic_arguments_from_options(opts));
     }
 };

--- a/src/search/pdbs/pdb_heuristic.h
+++ b/src/search/pdbs/pdb_heuristic.h
@@ -25,8 +25,9 @@ public:
        empty, default operator costs are used.
     */
     PDBHeuristic(
+        const std::shared_ptr<AbstractTask> &task,
         const std::shared_ptr<PatternGenerator> &pattern_generator,
-        const std::shared_ptr<AbstractTask> &transform, bool cache_estimates,
+        bool cache_estimates,
         const std::string &description, utils::Verbosity verbosity);
 };
 }

--- a/src/search/pdbs/zero_one_pdbs_heuristic.cc
+++ b/src/search/pdbs/zero_one_pdbs_heuristic.cc
@@ -19,10 +19,11 @@ static ZeroOnePDBs get_zero_one_pdbs_from_generator(
 }
 
 ZeroOnePDBsHeuristic::ZeroOnePDBsHeuristic(
+    const shared_ptr<AbstractTask> &task,
     const shared_ptr<PatternCollectionGenerator> &patterns,
-    const shared_ptr<AbstractTask> &transform, bool cache_estimates,
+    bool cache_estimates,
     const string &description, utils::Verbosity verbosity)
-    : Heuristic(transform, cache_estimates, description, verbosity),
+    : Heuristic(task, cache_estimates, description, verbosity),
       zero_one_pdbs(get_zero_one_pdbs_from_generator(task, patterns)) {
 }
 
@@ -35,9 +36,9 @@ int ZeroOnePDBsHeuristic::compute_heuristic(const State &ancestor_state) {
 }
 
 class ZeroOnePDBsHeuristicFeature
-    : public plugins::TypedFeature<Evaluator, ZeroOnePDBsHeuristic> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
-    ZeroOnePDBsHeuristicFeature() : TypedFeature("zopdbs") {
+    ZeroOnePDBsHeuristicFeature() : TaskIndependentFeature("zopdbs") {
         document_subcategory("heuristics_pdb");
         document_title("Zero-One PDB");
         document_synopsis(
@@ -51,7 +52,7 @@ public:
             "into account for one pattern (the first one which it affects) and set "
             "to zero for all other affected patterns.");
 
-        add_option<shared_ptr<PatternCollectionGenerator>>(
+        add_option<shared_ptr<TaskIndependentPatternCollectionGenerator>>(
             "patterns", "pattern generation method", "systematic(1)");
         add_heuristic_options_to_feature(*this, "zopdbs");
 
@@ -65,10 +66,10 @@ public:
         document_property("preferred operators", "no");
     }
 
-    virtual shared_ptr<ZeroOnePDBsHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<ZeroOnePDBsHeuristic>(
-            opts.get<shared_ptr<PatternCollectionGenerator>>("patterns"),
+        return components::make_auto_task_independent_component<ZeroOnePDBsHeuristic, Evaluator>(
+            opts.get<shared_ptr<TaskIndependentPatternCollectionGenerator>>("patterns"),
             get_heuristic_arguments_from_options(opts));
     }
 };

--- a/src/search/pdbs/zero_one_pdbs_heuristic.h
+++ b/src/search/pdbs/zero_one_pdbs_heuristic.h
@@ -15,8 +15,9 @@ protected:
     virtual int compute_heuristic(const State &ancestor_state) override;
 public:
     ZeroOnePDBsHeuristic(
+        const std::shared_ptr<AbstractTask> &task,
         const std::shared_ptr<PatternCollectionGenerator> &patterns,
-        const std::shared_ptr<AbstractTask> &transform, bool cache_estimates,
+        bool cache_estimates,
         const std::string &name, utils::Verbosity verbosity);
 };
 }

--- a/src/search/plugins/plugin.h
+++ b/src/search/plugins/plugin.h
@@ -75,44 +75,20 @@ public:
     const std::vector<NoteInfo> &get_notes() const;
 };
 
-template<typename Constructed>
-class FeatureWithDefault : public Feature {
+template<typename ComponentType>
+class TaskIndependentFeature : public Feature {
+    using ComponentTypePtr = std::shared_ptr<ComponentType>;
 protected:
     using Feature::Feature;
-    virtual std::shared_ptr<Constructed> create_component(
-        const Options &options) const {
-        return std::make_shared<Constructed>(options);
-    }
-};
-
-template<typename Constructed>
-class FeatureWithoutDefault : public Feature {
-protected:
-    using Feature::Feature;
-    virtual std::shared_ptr<Constructed> create_component(
-        const Options &) const = 0;
-};
-
-template<typename Constructed>
-using FeatureAuto = typename std::conditional<
-    std::is_constructible<Constructed, const Options &>::value,
-    FeatureWithDefault<Constructed>, FeatureWithoutDefault<Constructed>>::type;
-
-template<typename Base, typename Constructed>
-class TypedFeature : public FeatureAuto<Constructed> {
-    using BasePtr = std::shared_ptr<Base>;
-    static_assert(
-        std::is_base_of<Base, Constructed>::value,
-        "Constructed must derive from Base");
+    virtual ComponentTypePtr create_component(const Options &) const = 0;
 public:
-    TypedFeature(const std::string &key)
-        : FeatureAuto<Constructed>(
-              TypeRegistry::instance()->get_type<BasePtr>(), key) {
+    TaskIndependentFeature(const std::string &key)
+        : Feature(TypeRegistry::instance()->get_type<ComponentTypePtr>(), key) {
     }
 
     Any construct(
         const Options &options, const utils::Context &context) const override {
-        std::shared_ptr<Base> ptr;
+        ComponentTypePtr ptr;
         try {
             ptr = this->create_component(options);
         } catch (const utils::ComponentArgumentError &e) {
@@ -182,9 +158,9 @@ class CategoryPlugin {
     /*
       TODO: Currently, we do not support variable binding of all categories, so
       variables can only be used for categories explicitly marked. This might
-      change once we fix the component interaction (issue559). If all feature
-      types can be bound to variables, we can probably get rid of this flag and
-      related code in CategoryPlugin, TypedCategoryPlugin, RawRegistry,
+      change once we remove the old task transformation code (issue1208). If all
+      feature types can be bound to variables, we can probably get rid of this
+      flag and related code in CategoryPlugin, TypedCategoryPlugin, RawRegistry,
       Registry, Parser, ...
     */
     bool can_be_bound_to_variable;

--- a/src/search/pruning/limited_pruning.cc
+++ b/src/search/pruning/limited_pruning.cc
@@ -7,9 +7,10 @@ using namespace std;
 
 namespace limited_pruning {
 LimitedPruning::LimitedPruning(
+    const shared_ptr<AbstractTask> &task,
     const shared_ptr<PruningMethod> &pruning, double min_required_pruning_ratio,
     int expansions_before_checking_pruning_ratio, utils::Verbosity verbosity)
-    : PruningMethod(verbosity),
+    : PruningMethod(task, verbosity),
       pruning_method(pruning),
       min_required_pruning_ratio(min_required_pruning_ratio),
       num_expansions_before_checking_pruning_ratio(
@@ -55,9 +56,9 @@ void LimitedPruning::prune(const State &state, vector<OperatorID> &op_ids) {
 }
 
 class LimitedPruningFeature
-    : public plugins::TypedFeature<PruningMethod, LimitedPruning> {
+    : public plugins::TaskIndependentFeature<TaskIndependentPruningMethod> {
 public:
-    LimitedPruningFeature() : TypedFeature("limited_pruning") {
+    LimitedPruningFeature() : TaskIndependentFeature("limited_pruning") {
         document_title("Limited pruning");
         document_synopsis(
             "Limited pruning applies another pruning method and switches it off "
@@ -66,7 +67,7 @@ public:
             "divided by the sum of all operators before pruning, considering all "
             "previous expansions.");
 
-        add_option<shared_ptr<PruningMethod>>(
+        add_option<shared_ptr<TaskIndependentPruningMethod>>(
             "pruning", "the underlying pruning method to be applied");
         add_option<double>(
             "min_required_pruning_ratio",
@@ -87,10 +88,10 @@ public:
             "in an eager search such as astar.");
     }
 
-    virtual shared_ptr<LimitedPruning> create_component(
+    virtual shared_ptr<TaskIndependentPruningMethod> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<LimitedPruning>(
-            opts.get<shared_ptr<PruningMethod>>("pruning"),
+        return components::make_auto_task_independent_component<LimitedPruning, PruningMethod>(
+            opts.get<shared_ptr<TaskIndependentPruningMethod>>("pruning"),
             opts.get<double>("min_required_pruning_ratio"),
             opts.get<int>("expansions_before_checking_pruning_ratio"),
             get_pruning_arguments_from_options(opts));

--- a/src/search/pruning/limited_pruning.h
+++ b/src/search/pruning/limited_pruning.h
@@ -19,6 +19,7 @@ class LimitedPruning : public PruningMethod {
         const State &state, std::vector<OperatorID> &op_ids) override;
 public:
     explicit LimitedPruning(
+        const std::shared_ptr<AbstractTask> &task,
         const std::shared_ptr<PruningMethod> &pruning,
         double min_required_pruning_ratio,
         int expansions_before_checking_pruning_ratio,

--- a/src/search/pruning/null_pruning_method.cc
+++ b/src/search/pruning/null_pruning_method.cc
@@ -6,8 +6,8 @@
 using namespace std;
 
 namespace null_pruning_method {
-NullPruningMethod::NullPruningMethod(utils::Verbosity verbosity)
-    : PruningMethod(verbosity) {
+NullPruningMethod::NullPruningMethod(const shared_ptr<AbstractTask> &task, utils::Verbosity verbosity)
+    : PruningMethod(task, verbosity) {
 }
 
 void NullPruningMethod::initialize(const shared_ptr<AbstractTask> &task) {
@@ -16,9 +16,9 @@ void NullPruningMethod::initialize(const shared_ptr<AbstractTask> &task) {
 }
 
 class NullPruningMethodFeature
-    : public plugins::TypedFeature<PruningMethod, NullPruningMethod> {
+    : public plugins::TaskIndependentFeature<TaskIndependentPruningMethod> {
 public:
-    NullPruningMethodFeature() : TypedFeature("null") {
+    NullPruningMethodFeature() : TaskIndependentFeature("null") {
         // document_group("");
         document_title("No pruning");
         document_synopsis(
@@ -28,9 +28,9 @@ public:
         add_pruning_options_to_feature(*this);
     }
 
-    virtual shared_ptr<NullPruningMethod> create_component(
+    virtual shared_ptr<TaskIndependentPruningMethod> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<NullPruningMethod>(
+        return components::make_auto_task_independent_component<NullPruningMethod, PruningMethod>(
             get_pruning_arguments_from_options(opts));
     }
 };

--- a/src/search/pruning/null_pruning_method.h
+++ b/src/search/pruning/null_pruning_method.h
@@ -8,7 +8,7 @@ class NullPruningMethod : public PruningMethod {
     virtual void prune(const State &, std::vector<OperatorID> &) override {
     }
 public:
-    explicit NullPruningMethod(utils::Verbosity verbosity);
+    explicit NullPruningMethod(const std::shared_ptr<AbstractTask> &task, utils::Verbosity verbosity);
     virtual void initialize(const std::shared_ptr<AbstractTask> &) override;
     virtual void print_statistics() const override {
     }

--- a/src/search/pruning/stubborn_sets.cc
+++ b/src/search/pruning/stubborn_sets.cc
@@ -6,8 +6,8 @@
 using namespace std;
 
 namespace stubborn_sets {
-StubbornSets::StubbornSets(utils::Verbosity verbosity)
-    : PruningMethod(verbosity), num_operators(-1) {
+StubbornSets::StubbornSets(const shared_ptr<AbstractTask> &task, utils::Verbosity verbosity)
+    : PruningMethod(task, verbosity), num_operators(-1) {
 }
 
 void StubbornSets::initialize(const shared_ptr<AbstractTask> &task) {

--- a/src/search/pruning/stubborn_sets.h
+++ b/src/search/pruning/stubborn_sets.h
@@ -56,7 +56,7 @@ protected:
 
     virtual void compute_stubborn_set(const State &state) = 0;
 public:
-    explicit StubbornSets(utils::Verbosity verbosity);
+    explicit StubbornSets(const std::shared_ptr<AbstractTask> &task, utils::Verbosity verbosity);
     virtual void initialize(const std::shared_ptr<AbstractTask> &task) override;
 };
 

--- a/src/search/pruning/stubborn_sets_action_centric.cc
+++ b/src/search/pruning/stubborn_sets_action_centric.cc
@@ -23,8 +23,8 @@ static bool contain_conflicting_fact(
     return false;
 }
 
-StubbornSetsActionCentric::StubbornSetsActionCentric(utils::Verbosity verbosity)
-    : StubbornSets(verbosity) {
+StubbornSetsActionCentric::StubbornSetsActionCentric(const shared_ptr<AbstractTask> &task, utils::Verbosity verbosity)
+    : StubbornSets(task, verbosity) {
 }
 
 void StubbornSetsActionCentric::compute_stubborn_set(const State &state) {

--- a/src/search/pruning/stubborn_sets_action_centric.h
+++ b/src/search/pruning/stubborn_sets_action_centric.h
@@ -17,7 +17,7 @@ class StubbornSetsActionCentric : public stubborn_sets::StubbornSets {
     virtual void handle_stubborn_operator(const State &state, int op_no) = 0;
     virtual void compute_stubborn_set(const State &state) override;
 protected:
-    explicit StubbornSetsActionCentric(utils::Verbosity verbosity);
+    explicit StubbornSetsActionCentric(const std::shared_ptr<AbstractTask> &task, utils::Verbosity verbosity);
     bool can_disable(int op1_no, int op2_no) const;
     bool can_conflict(int op1_no, int op2_no) const;
 

--- a/src/search/pruning/stubborn_sets_atom_centric.cc
+++ b/src/search/pruning/stubborn_sets_atom_centric.cc
@@ -10,9 +10,10 @@ using namespace std;
 
 namespace stubborn_sets_atom_centric {
 StubbornSetsAtomCentric::StubbornSetsAtomCentric(
+    const shared_ptr<AbstractTask> &task,
     bool use_sibling_shortcut, AtomSelectionStrategy atom_selection_strategy,
     utils::Verbosity verbosity)
-    : StubbornSets(verbosity),
+    : StubbornSets(task, verbosity),
       use_sibling_shortcut(use_sibling_shortcut),
       atom_selection_strategy(atom_selection_strategy) {
 }
@@ -252,10 +253,10 @@ void StubbornSetsAtomCentric::handle_stubborn_operator(
 }
 
 class StubbornSetsAtomCentricFeature
-    : public plugins::TypedFeature<PruningMethod, StubbornSetsAtomCentric> {
+    : public plugins::TaskIndependentFeature<TaskIndependentPruningMethod> {
 public:
     StubbornSetsAtomCentricFeature()
-        : TypedFeature("atom_centric_stubborn_sets") {
+        : TaskIndependentFeature("atom_centric_stubborn_sets") {
         document_title("Atom-centric stubborn sets");
         document_synopsis(
             "Stubborn sets are a state pruning method which computes a subset "
@@ -286,9 +287,9 @@ public:
         add_pruning_options_to_feature(*this);
     }
 
-    virtual shared_ptr<StubbornSetsAtomCentric> create_component(
+    virtual shared_ptr<TaskIndependentPruningMethod> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<StubbornSetsAtomCentric>(
+        return components::make_auto_task_independent_component<StubbornSetsAtomCentric, PruningMethod>(
             opts.get<bool>("use_sibling_shortcut"),
             opts.get<AtomSelectionStrategy>("atom_selection_strategy"),
             get_pruning_arguments_from_options(opts));

--- a/src/search/pruning/stubborn_sets_atom_centric.h
+++ b/src/search/pruning/stubborn_sets_atom_centric.h
@@ -54,6 +54,7 @@ class StubbornSetsAtomCentric : public stubborn_sets::StubbornSets {
     virtual void compute_stubborn_set(const State &state) override;
 public:
     explicit StubbornSetsAtomCentric(
+        const std::shared_ptr<AbstractTask> &task,
         bool use_sibling_shortcut,
         AtomSelectionStrategy atom_selection_strategy,
         utils::Verbosity verbosity);

--- a/src/search/pruning/stubborn_sets_ec.cc
+++ b/src/search/pruning/stubborn_sets_ec.cc
@@ -101,8 +101,8 @@ static void get_conflicting_vars(
     }
 }
 
-StubbornSetsEC::StubbornSetsEC(utils::Verbosity verbosity)
-    : StubbornSetsActionCentric(verbosity) {
+StubbornSetsEC::StubbornSetsEC(const shared_ptr<AbstractTask> &task, utils::Verbosity verbosity)
+    : StubbornSetsActionCentric(task, verbosity) {
 }
 
 void StubbornSetsEC::initialize(const shared_ptr<AbstractTask> &task) {
@@ -330,9 +330,9 @@ void StubbornSetsEC::handle_stubborn_operator(const State &state, int op_no) {
 }
 
 class StubbornSetsECFeature
-    : public plugins::TypedFeature<PruningMethod, StubbornSetsEC> {
+    : public plugins::TaskIndependentFeature<TaskIndependentPruningMethod> {
 public:
-    StubbornSetsECFeature() : TypedFeature("stubborn_sets_ec") {
+    StubbornSetsECFeature() : TaskIndependentFeature("stubborn_sets_ec") {
         document_title("StubbornSetsEC");
         document_synopsis(
             "Stubborn sets represent a state pruning method which computes a subset "
@@ -353,9 +353,9 @@ public:
         add_pruning_options_to_feature(*this);
     }
 
-    virtual shared_ptr<StubbornSetsEC> create_component(
+    virtual shared_ptr<TaskIndependentPruningMethod> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<StubbornSetsEC>(
+        return components::make_auto_task_independent_component<StubbornSetsEC, PruningMethod>(
             get_pruning_arguments_from_options(opts));
     }
 };

--- a/src/search/pruning/stubborn_sets_ec.h
+++ b/src/search/pruning/stubborn_sets_ec.h
@@ -34,7 +34,7 @@ protected:
     virtual void handle_stubborn_operator(
         const State &state, int op_no) override;
 public:
-    explicit StubbornSetsEC(utils::Verbosity verbosity);
+    explicit StubbornSetsEC(const std::shared_ptr<AbstractTask> &task, utils::Verbosity verbosity);
     virtual void initialize(const std::shared_ptr<AbstractTask> &task) override;
 };
 }

--- a/src/search/pruning/stubborn_sets_simple.cc
+++ b/src/search/pruning/stubborn_sets_simple.cc
@@ -7,8 +7,9 @@
 using namespace std;
 
 namespace stubborn_sets_simple {
-StubbornSetsSimple::StubbornSetsSimple(utils::Verbosity verbosity)
-    : StubbornSetsActionCentric(verbosity) {
+StubbornSetsSimple::StubbornSetsSimple(
+    const shared_ptr<AbstractTask> &task, utils::Verbosity verbosity)
+    : StubbornSetsActionCentric(task, verbosity) {
 }
 
 void StubbornSetsSimple::initialize(const shared_ptr<AbstractTask> &task) {
@@ -75,9 +76,9 @@ void StubbornSetsSimple::handle_stubborn_operator(
 }
 
 class StubbornSetsSimpleFeature
-    : public plugins::TypedFeature<PruningMethod, StubbornSetsSimple> {
+    : public plugins::TaskIndependentFeature<TaskIndependentPruningMethod> {
 public:
-    StubbornSetsSimpleFeature() : TypedFeature("stubborn_sets_simple") {
+    StubbornSetsSimpleFeature() : TaskIndependentFeature("stubborn_sets_simple") {
         document_title("Stubborn sets simple");
         document_synopsis(
             "Stubborn sets represent a state pruning method which computes a subset "
@@ -104,9 +105,9 @@ public:
         add_pruning_options_to_feature(*this);
     }
 
-    virtual shared_ptr<StubbornSetsSimple> create_component(
+    virtual shared_ptr<TaskIndependentPruningMethod> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<StubbornSetsSimple>(
+        return components::make_auto_task_independent_component<StubbornSetsSimple, PruningMethod>(
             get_pruning_arguments_from_options(opts));
     }
 };

--- a/src/search/pruning/stubborn_sets_simple.h
+++ b/src/search/pruning/stubborn_sets_simple.h
@@ -25,7 +25,7 @@ protected:
     virtual void handle_stubborn_operator(
         const State &state, int op_no) override;
 public:
-    explicit StubbornSetsSimple(utils::Verbosity verbosity);
+    explicit StubbornSetsSimple(const std::shared_ptr<AbstractTask> &task, utils::Verbosity verbosity);
     virtual void initialize(const std::shared_ptr<AbstractTask> &task) override;
 };
 }

--- a/src/search/pruning_method.cc
+++ b/src/search/pruning_method.cc
@@ -8,8 +8,8 @@
 
 using namespace std;
 
-PruningMethod::PruningMethod(utils::Verbosity verbosity)
-    : timer(false),
+PruningMethod::PruningMethod(const shared_ptr<AbstractTask> &task, utils::Verbosity verbosity)
+    : components::TaskSpecificComponent(task), timer(false),
       log(utils::get_log_for_verbosity(verbosity)),
       task(nullptr) {
 }
@@ -76,7 +76,7 @@ tuple<utils::Verbosity> get_pruning_arguments_from_options(
 }
 
 static class PruningMethodCategoryPlugin
-    : public plugins::TypedCategoryPlugin<PruningMethod> {
+    : public plugins::TypedCategoryPlugin<TaskIndependentPruningMethod> {
 public:
     PruningMethodCategoryPlugin() : TypedCategoryPlugin("PruningMethod") {
         document_synopsis(

--- a/src/search/pruning_method.h
+++ b/src/search/pruning_method.h
@@ -1,6 +1,7 @@
 #ifndef PRUNING_METHOD_H
 #define PRUNING_METHOD_H
 
+#include "component.h"
 #include "operator_id.h"
 
 #include "utils/logging.h"
@@ -21,7 +22,7 @@ class Options;
 class Feature;
 }
 
-class PruningMethod {
+class PruningMethod : public components::TaskSpecificComponent {
     utils::Timer timer;
     friend class limited_pruning::LimitedPruning;
 
@@ -32,12 +33,13 @@ protected:
     long num_successors_before_pruning;
     long num_successors_after_pruning;
 public:
-    explicit PruningMethod(utils::Verbosity verbosity);
-    virtual ~PruningMethod() = default;
+    PruningMethod(const std::shared_ptr<AbstractTask> &task, utils::Verbosity verbosity);
     virtual void initialize(const std::shared_ptr<AbstractTask> &task);
     void prune_operators(const State &state, std::vector<OperatorID> &op_ids);
     virtual void print_statistics() const;
 };
+using TaskIndependentPruningMethod =
+    components::TaskIndependentComponent<PruningMethod>;
 
 extern void add_pruning_options_to_feature(plugins::Feature &feature);
 extern std::tuple<utils::Verbosity> get_pruning_arguments_from_options(

--- a/src/search/search_algorithm.cc
+++ b/src/search/search_algorithm.cc
@@ -2,6 +2,7 @@
 
 #include "evaluation_context.h"
 #include "evaluator.h"
+#include "pruning_method.h"
 
 #include "algorithms/ordered_set.h"
 #include "plugins/plugin.h"
@@ -39,13 +40,12 @@ static successor_generator::SuccessorGenerator &get_successor_generator(
 }
 
 SearchAlgorithm::SearchAlgorithm(
+    const shared_ptr<AbstractTask> &task,
     OperatorCost cost_type, int bound, double max_time,
     const string &description, utils::Verbosity verbosity)
-    : description(description),
+    : components::TaskSpecificComponent(task), description(description),
       status(IN_PROGRESS),
       solution_found(false),
-      task(tasks::g_root_task),
-      task_proxy(*task),
       log(utils::get_log_for_verbosity(verbosity)),
       state_registry(task_proxy),
       successor_generator(get_successor_generator(task_proxy, log)),
@@ -60,35 +60,6 @@ SearchAlgorithm::SearchAlgorithm(
         utils::exit_with(ExitCode::SEARCH_INPUT_ERROR);
     }
     task_properties::print_variable_statistics(task_proxy);
-}
-
-SearchAlgorithm::SearchAlgorithm(
-    const plugins::Options
-        &opts) // TODO options object is needed for iterated search, the
-               // prototype for issue559 resolves this
-    : description(opts.get_unparsed_config()),
-      status(IN_PROGRESS),
-      solution_found(false),
-      task(tasks::g_root_task),
-      task_proxy(*task),
-      log(utils::get_log_for_verbosity(
-          opts.get<utils::Verbosity>("verbosity"))),
-      state_registry(task_proxy),
-      successor_generator(get_successor_generator(task_proxy, log)),
-      search_space(state_registry, log),
-      statistics(log),
-      cost_type(opts.get<OperatorCost>("cost_type")),
-      is_unit_cost(task_properties::is_unit_cost(task_proxy)),
-      max_time(opts.get<double>("max_time")) {
-    if (opts.get<int>("bound") < 0) {
-        cerr << "error: negative cost bound " << opts.get<int>("bound") << endl;
-        utils::exit_with(ExitCode::SEARCH_INPUT_ERROR);
-    }
-    bound = opts.get<int>("bound");
-    task_properties::print_variable_statistics(task_proxy);
-}
-
-SearchAlgorithm::~SearchAlgorithm() {
 }
 
 bool SearchAlgorithm::found_solution() const {
@@ -161,7 +132,7 @@ void print_initial_evaluator_values(const EvaluationContext &eval_context) {
    classes.
    TODO: Figure out where it belongs and move it there. */
 void add_search_pruning_options_to_feature(plugins::Feature &feature) {
-    feature.add_option<shared_ptr<PruningMethod>>(
+    feature.add_option<shared_ptr<TaskIndependentPruningMethod>>(
         "pruning",
         "Pruning methods can prune or reorder the set of applicable operators in "
         "each state and thereby influence the number and order of successor states "
@@ -169,9 +140,10 @@ void add_search_pruning_options_to_feature(plugins::Feature &feature) {
         "null()");
 }
 
-tuple<shared_ptr<PruningMethod>> get_search_pruning_arguments_from_options(
+tuple<shared_ptr<TaskIndependentPruningMethod>>
+get_search_pruning_arguments_from_options(
     const plugins::Options &opts) {
-    return make_tuple(opts.get<shared_ptr<PruningMethod>>("pruning"));
+    return make_tuple(opts.get<shared_ptr<TaskIndependentPruningMethod>>("pruning"));
 }
 
 void add_search_algorithm_options_to_feature(
@@ -235,7 +207,7 @@ tuple<bool, bool, int> get_successors_order_arguments_from_options(
 }
 
 static class SearchAlgorithmCategoryPlugin
-    : public plugins::TypedCategoryPlugin<SearchAlgorithm> {
+    : public plugins::TypedCategoryPlugin<TaskIndependentSearchAlgorithm> {
 public:
     SearchAlgorithmCategoryPlugin() : TypedCategoryPlugin("SearchAlgorithm") {
         // TODO: Replace add synopsis for the wiki page.

--- a/src/search/search_algorithm.h
+++ b/src/search/search_algorithm.h
@@ -1,9 +1,11 @@
 #ifndef SEARCH_ALGORITHM_H
 #define SEARCH_ALGORITHM_H
 
+#include "component.h"
 #include "operator_cost.h"
 #include "operator_id.h"
 #include "plan_manager.h"
+#include "pruning_method.h"
 #include "search_progress.h"
 #include "search_space.h"
 #include "search_statistics.h"
@@ -35,18 +37,12 @@ enum SearchStatus {
     SOLVED
 };
 
-class SearchAlgorithm {
+class SearchAlgorithm : public components::TaskSpecificComponent {
     std::string description;
     SearchStatus status;
     bool solution_found;
     Plan plan;
 protected:
-    // Hold a reference to the task implementation and pass it to objects that
-    // need it.
-    const std::shared_ptr<AbstractTask> task;
-    // Use task_proxy to access task information.
-    TaskProxy task_proxy;
-
     mutable utils::LogProxy log;
     PlanManager plan_manager;
     StateRegistry state_registry;
@@ -68,13 +64,9 @@ protected:
     int get_adjusted_cost(const OperatorProxy &op) const;
 public:
     SearchAlgorithm(
+        const std::shared_ptr<AbstractTask> &task,
         OperatorCost cost_type, int bound, double max_time,
         const std::string &description, utils::Verbosity verbosity);
-    explicit SearchAlgorithm(
-        const plugins::Options
-            &opts); // TODO options object is needed for iterated search, the
-                    // prototype for issue559 resolves this
-    virtual ~SearchAlgorithm();
     virtual void print_statistics() const = 0;
     virtual void save_plan_if_necessary();
     bool found_solution() const;
@@ -98,6 +90,9 @@ public:
     }
 };
 
+using TaskIndependentSearchAlgorithm =
+    components::TaskIndependentComponent<SearchAlgorithm>;
+
 /*
   Print evaluator values of all evaluators evaluated in the evaluation context.
 */
@@ -108,10 +103,8 @@ extern void collect_preferred_operators(
     EvaluationContext &eval_context, Evaluator *preferred_operator_evaluator,
     ordered_set::OrderedSet<OperatorID> &preferred_operators);
 
-class PruningMethod;
-
 extern void add_search_pruning_options_to_feature(plugins::Feature &feature);
-extern std::tuple<std::shared_ptr<PruningMethod>>
+extern std::tuple<std::shared_ptr<TaskIndependentPruningMethod>>
 get_search_pruning_arguments_from_options(const plugins::Options &opts);
 extern void add_search_algorithm_options_to_feature(
     plugins::Feature &feature, const std::string &description);

--- a/src/search/search_algorithms/eager_search.cc
+++ b/src/search/search_algorithms/eager_search.cc
@@ -20,6 +20,7 @@ using namespace std;
 
 namespace eager_search {
 EagerSearch::EagerSearch(
+    const shared_ptr<AbstractTask> &task,
     const shared_ptr<OpenListFactory> &open, bool reopen_closed,
     const shared_ptr<Evaluator> &f_eval,
     const vector<shared_ptr<Evaluator>> &preferred,
@@ -27,7 +28,7 @@ EagerSearch::EagerSearch(
     const shared_ptr<Evaluator> &lazy_evaluator, OperatorCost cost_type,
     int bound, double max_time, const string &description,
     utils::Verbosity verbosity)
-    : SearchAlgorithm(cost_type, bound, max_time, description, verbosity),
+    : SearchAlgorithm(task, cost_type, bound, max_time, description, verbosity),
       reopen_closed_nodes(reopen_closed),
       open_list(open->create_state_open_list()),
       f_evaluator(f_eval), // default nullptr
@@ -344,12 +345,12 @@ void add_eager_search_options_to_feature(
 }
 
 tuple<
-    shared_ptr<PruningMethod>, shared_ptr<Evaluator>, OperatorCost, int, double,
+    shared_ptr<TaskIndependentPruningMethod>, shared_ptr<TaskIndependentEvaluator>, OperatorCost, int, double,
     string, utils::Verbosity>
 get_eager_search_arguments_from_options(const plugins::Options &opts) {
     return tuple_cat(
         get_search_pruning_arguments_from_options(opts),
-        make_tuple(opts.get<shared_ptr<Evaluator>>("lazy_evaluator", nullptr)),
+        make_tuple(opts.get<shared_ptr<TaskIndependentEvaluator>>("lazy_evaluator", nullptr)),
         get_search_algorithm_arguments_from_options(opts));
 }
 }

--- a/src/search/search_algorithms/eager_search.h
+++ b/src/search/search_algorithms/eager_search.h
@@ -1,6 +1,7 @@
 #ifndef SEARCH_ALGORITHMS_EAGER_SEARCH_H
 #define SEARCH_ALGORITHMS_EAGER_SEARCH_H
 
+#include "../evaluator.h"
 #include "../open_list.h"
 #include "../search_algorithm.h"
 
@@ -45,7 +46,8 @@ protected:
     virtual SearchStatus step() override;
 
 public:
-    explicit EagerSearch(
+    EagerSearch(
+        const std::shared_ptr<AbstractTask> &task,
         const std::shared_ptr<OpenListFactory> &open, bool reopen_closed,
         const std::shared_ptr<Evaluator> &f_eval,
         const std::vector<std::shared_ptr<Evaluator>> &preferred,
@@ -62,7 +64,7 @@ public:
 extern void add_eager_search_options_to_feature(
     plugins::Feature &feature, const std::string &description);
 extern std::tuple<
-    std::shared_ptr<PruningMethod>, std::shared_ptr<Evaluator>, OperatorCost,
+    std::shared_ptr<TaskIndependentPruningMethod>, std::shared_ptr<TaskIndependentEvaluator>, OperatorCost,
     int, double, std::string, utils::Verbosity>
 get_eager_search_arguments_from_options(const plugins::Options &opts);
 }

--- a/src/search/search_algorithms/enforced_hill_climbing_search.cc
+++ b/src/search/search_algorithms/enforced_hill_climbing_search.cc
@@ -19,19 +19,19 @@ using PrefEval = pref_evaluator::PrefEvaluator;
 
 static shared_ptr<OpenListFactory> create_ehc_open_list_factory(
     utils::Verbosity verbosity, bool use_preferred,
-    PreferredUsage preferred_usage) {
+    PreferredUsage preferred_usage, const shared_ptr<AbstractTask> &task) {
     /*
       TODO: this g-evaluator should probably be set up to always
       ignore costs since EHC is supposed to implement a breadth-first
       search, not a uniform-cost search. So this seems to be a bug.
     */
     shared_ptr<Evaluator> g_evaluator =
-        make_shared<GEval>("ehc.g_eval", verbosity);
+        make_shared<GEval>(task, "ehc.g_eval", verbosity);
 
     if (!use_preferred ||
         preferred_usage == PreferredUsage::PRUNE_BY_PREFERRED) {
         return make_shared<standard_scalar_open_list::BestFirstOpenListFactory>(
-            g_evaluator, false);
+            task, g_evaluator, false);
     } else {
         /*
           TODO: Reduce code duplication with search_common.cc,
@@ -42,18 +42,19 @@ static shared_ptr<OpenListFactory> create_ehc_open_list_factory(
           open list code.
         */
         vector<shared_ptr<Evaluator>> evals = {
-            g_evaluator, make_shared<PrefEval>("ehc.pref_eval", verbosity)};
+            g_evaluator, make_shared<PrefEval>(task, "ehc.pref_eval", verbosity)};
         return make_shared<tiebreaking_open_list::TieBreakingOpenListFactory>(
-            evals, false, true);
+            task, evals, false, true);
     }
 }
 
 EnforcedHillClimbingSearch::EnforcedHillClimbingSearch(
+    const shared_ptr<AbstractTask> &task,
     const shared_ptr<Evaluator> &h, PreferredUsage preferred_usage,
     const vector<shared_ptr<Evaluator>> &preferred, OperatorCost cost_type,
     int bound, double max_time, const string &description,
     utils::Verbosity verbosity)
-    : SearchAlgorithm(cost_type, bound, max_time, description, verbosity),
+    : SearchAlgorithm(task, cost_type, bound, max_time, description, verbosity),
       evaluator(h),
       preferred_operator_evaluators(preferred),
       preferred_usage(preferred_usage),
@@ -76,7 +77,7 @@ EnforcedHillClimbingSearch::EnforcedHillClimbingSearch(
                         evaluator) != preferred_operator_evaluators.end();
 
     open_list =
-        create_ehc_open_list_factory(verbosity, use_preferred, preferred_usage)
+        create_ehc_open_list_factory(verbosity, use_preferred, preferred_usage, task)
             ->create_edge_open_list();
 }
 
@@ -260,28 +261,28 @@ void EnforcedHillClimbingSearch::print_statistics() const {
 }
 
 class EnforcedHillClimbingSearchFeature
-    : public plugins::TypedFeature<
-          SearchAlgorithm, EnforcedHillClimbingSearch> {
+    : public plugins::TaskIndependentFeature<
+          TaskIndependentSearchAlgorithm> {
 public:
-    EnforcedHillClimbingSearchFeature() : TypedFeature("ehc") {
+    EnforcedHillClimbingSearchFeature() : TaskIndependentFeature("ehc") {
         document_title("Lazy enforced hill-climbing");
         document_synopsis("");
 
-        add_option<shared_ptr<Evaluator>>("h", "heuristic");
+        add_option<shared_ptr<TaskIndependentEvaluator>>("h", "heuristic");
         add_option<PreferredUsage>(
             "preferred_usage", "preferred operator usage",
             "prune_by_preferred");
-        add_list_option<shared_ptr<Evaluator>>(
+        add_list_option<shared_ptr<TaskIndependentEvaluator>>(
             "preferred", "use preferred operators of these evaluators", "[]");
         add_search_algorithm_options_to_feature(*this, "ehc");
     }
 
-    virtual shared_ptr<EnforcedHillClimbingSearch> create_component(
+    virtual shared_ptr<TaskIndependentSearchAlgorithm> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<EnforcedHillClimbingSearch>(
-            opts.get<shared_ptr<Evaluator>>("h"),
+        return components::make_auto_task_independent_component<EnforcedHillClimbingSearch, SearchAlgorithm>(
+            opts.get<shared_ptr<TaskIndependentEvaluator>>("h"),
             opts.get<PreferredUsage>("preferred_usage"),
-            opts.get_list<shared_ptr<Evaluator>>("preferred"),
+            opts.get_list<shared_ptr<TaskIndependentEvaluator>>("preferred"),
             get_search_algorithm_arguments_from_options(opts));
     }
 };

--- a/src/search/search_algorithms/enforced_hill_climbing_search.h
+++ b/src/search/search_algorithms/enforced_hill_climbing_search.h
@@ -58,6 +58,7 @@ protected:
 
 public:
     EnforcedHillClimbingSearch(
+        const std::shared_ptr<AbstractTask> &task,
         const std::shared_ptr<Evaluator> &h, PreferredUsage preferred_usage,
         const std::vector<std::shared_ptr<Evaluator>> &preferred,
         OperatorCost cost_type, int bound, double max_time,

--- a/src/search/search_algorithms/lazy_search.cc
+++ b/src/search/search_algorithms/lazy_search.cc
@@ -18,12 +18,13 @@ using namespace std;
 
 namespace lazy_search {
 LazySearch::LazySearch(
+    const shared_ptr<AbstractTask> &task,
     const shared_ptr<OpenListFactory> &open, bool reopen_closed,
     const vector<shared_ptr<Evaluator>> &preferred, bool randomize_successors,
     bool preferred_successors_first, int random_seed, OperatorCost cost_type,
     int bound, double max_time, const string &description,
     utils::Verbosity verbosity)
-    : SearchAlgorithm(cost_type, bound, max_time, description, verbosity),
+    : SearchAlgorithm(task, cost_type, bound, max_time, description, verbosity),
       open_list(open->create_edge_open_list()),
       reopen_closed_nodes(reopen_closed),
       randomize_successors(randomize_successors),

--- a/src/search/search_algorithms/lazy_search.h
+++ b/src/search/search_algorithms/lazy_search.h
@@ -51,6 +51,7 @@ protected:
 
 public:
     LazySearch(
+        const std::shared_ptr<AbstractTask> &task,
         const std::shared_ptr<OpenListFactory> &open, bool reopen_closed,
         const std::vector<std::shared_ptr<Evaluator>> &evaluators,
         bool randomize_successors, bool preferred_successors_first,

--- a/src/search/search_algorithms/plugin_astar.cc
+++ b/src/search/search_algorithms/plugin_astar.cc
@@ -7,17 +7,17 @@ using namespace std;
 
 namespace plugin_astar {
 class AStarSearchFeature
-    : public plugins::TypedFeature<SearchAlgorithm, eager_search::EagerSearch> {
+    : public plugins::TaskIndependentFeature<TaskIndependentSearchAlgorithm> {
 public:
-    AStarSearchFeature() : TypedFeature("astar") {
+    AStarSearchFeature() : TaskIndependentFeature("astar") {
         document_title("A* search (eager)");
         document_synopsis(
             "A* is a special case of eager best first search that uses g+h "
             "as f-function. "
             "We break ties using the evaluator. Closed nodes are re-opened.");
 
-        add_option<shared_ptr<Evaluator>>("eval", "evaluator for h-value");
-        add_option<shared_ptr<Evaluator>>(
+        add_option<shared_ptr<TaskIndependentEvaluator>>("eval", "evaluator for h-value");
+        add_option<shared_ptr<TaskIndependentEvaluator>>(
             "lazy_evaluator",
             "An evaluator that re-evaluates a state before it is expanded.",
             plugins::ArgumentInfo::NO_DEFAULT);
@@ -40,22 +40,22 @@ public:
             true);
     }
 
-    virtual shared_ptr<eager_search::EagerSearch> create_component(
+    virtual shared_ptr<TaskIndependentSearchAlgorithm> create_component(
         const plugins::Options &opts) const override {
         plugins::Options options_copy(opts);
         auto temp = search_common::create_astar_open_list_factory_and_f_eval(
-            opts.get<shared_ptr<Evaluator>>("eval"),
+            opts.get<shared_ptr<TaskIndependentEvaluator>>("eval"),
             opts.get<utils::Verbosity>("verbosity"));
         options_copy.set("open", temp.first);
         options_copy.set("f_eval", temp.second);
         options_copy.set("reopen_closed", true);
-        vector<shared_ptr<Evaluator>> preferred_list;
+        vector<shared_ptr<TaskIndependentEvaluator>> preferred_list;
         options_copy.set("preferred", preferred_list);
-        return plugins::make_shared_from_arg_tuples<eager_search::EagerSearch>(
-            options_copy.get<shared_ptr<OpenListFactory>>("open"),
+        return components::make_auto_task_independent_component<eager_search::EagerSearch, SearchAlgorithm>(
+            options_copy.get<shared_ptr<TaskIndependentOpenListFactory>>("open"),
             options_copy.get<bool>("reopen_closed"),
-            options_copy.get<shared_ptr<Evaluator>>("f_eval", nullptr),
-            options_copy.get_list<shared_ptr<Evaluator>>("preferred"),
+            options_copy.get<shared_ptr<TaskIndependentEvaluator>>("f_eval", nullptr),
+            options_copy.get_list<shared_ptr<TaskIndependentEvaluator>>("preferred"),
             eager_search::get_eager_search_arguments_from_options(
                 options_copy));
     }

--- a/src/search/search_algorithms/plugin_eager.cc
+++ b/src/search/search_algorithms/plugin_eager.cc
@@ -7,31 +7,31 @@ using namespace std;
 
 namespace plugin_eager {
 class EagerSearchFeature
-    : public plugins::TypedFeature<SearchAlgorithm, eager_search::EagerSearch> {
+    : public plugins::TaskIndependentFeature<TaskIndependentSearchAlgorithm> {
 public:
-    EagerSearchFeature() : TypedFeature("eager") {
+    EagerSearchFeature() : TaskIndependentFeature("eager") {
         document_title("Eager best-first search");
         document_synopsis("");
 
-        add_option<shared_ptr<OpenListFactory>>("open", "open list");
+        add_option<shared_ptr<TaskIndependentOpenListFactory>>("open", "open list");
         add_option<bool>("reopen_closed", "reopen closed nodes", "false");
-        add_option<shared_ptr<Evaluator>>(
+        add_option<shared_ptr<TaskIndependentEvaluator>>(
             "f_eval",
             "set evaluator for jump statistics. "
             "(Optional; if no evaluator is used, jump statistics will not be displayed.)",
             plugins::ArgumentInfo::NO_DEFAULT);
-        add_list_option<shared_ptr<Evaluator>>(
+        add_list_option<shared_ptr<TaskIndependentEvaluator>>(
             "preferred", "use preferred operators of these evaluators", "[]");
         eager_search::add_eager_search_options_to_feature(*this, "eager");
     }
 
-    virtual shared_ptr<eager_search::EagerSearch> create_component(
+    virtual shared_ptr<TaskIndependentSearchAlgorithm> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<eager_search::EagerSearch>(
-            opts.get<shared_ptr<OpenListFactory>>("open"),
+        return components::make_auto_task_independent_component<eager_search::EagerSearch, SearchAlgorithm>(
+            opts.get<shared_ptr<TaskIndependentOpenListFactory>>("open"),
             opts.get<bool>("reopen_closed"),
-            opts.get<shared_ptr<Evaluator>>("f_eval", nullptr),
-            opts.get_list<shared_ptr<Evaluator>>("preferred"),
+            opts.get<shared_ptr<TaskIndependentEvaluator>>("f_eval", nullptr),
+            opts.get_list<shared_ptr<TaskIndependentEvaluator>>("preferred"),
             eager_search::get_eager_search_arguments_from_options(opts));
     }
 };

--- a/src/search/search_algorithms/plugin_eager_greedy.cc
+++ b/src/search/search_algorithms/plugin_eager_greedy.cc
@@ -7,14 +7,14 @@ using namespace std;
 
 namespace plugin_eager_greedy {
 class EagerGreedySearchFeature
-    : public plugins::TypedFeature<SearchAlgorithm, eager_search::EagerSearch> {
+    : public plugins::TaskIndependentFeature<TaskIndependentSearchAlgorithm> {
 public:
-    EagerGreedySearchFeature() : TypedFeature("eager_greedy") {
+    EagerGreedySearchFeature() : TaskIndependentFeature("eager_greedy") {
         document_title("Greedy search (eager)");
         document_synopsis("");
 
-        add_list_option<shared_ptr<Evaluator>>("evals", "evaluators");
-        add_list_option<shared_ptr<Evaluator>>(
+        add_list_option<shared_ptr<TaskIndependentEvaluator>>("evals", "evaluators");
+        add_list_option<shared_ptr<TaskIndependentEvaluator>>(
             "preferred", "use preferred operators of these evaluators", "[]");
         add_option<int>(
             "boost", "boost value for preferred operator open lists", "0");
@@ -56,14 +56,14 @@ public:
             true);
     }
 
-    virtual shared_ptr<eager_search::EagerSearch> create_component(
+    virtual shared_ptr<TaskIndependentSearchAlgorithm> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<eager_search::EagerSearch>(
+        return components::make_auto_task_independent_component<eager_search::EagerSearch, SearchAlgorithm>(
             search_common::create_greedy_open_list_factory(
-                opts.get_list<shared_ptr<Evaluator>>("evals"),
-                opts.get_list<shared_ptr<Evaluator>>("preferred"),
+                opts.get_list<shared_ptr<TaskIndependentEvaluator>>("evals"),
+                opts.get_list<shared_ptr<TaskIndependentEvaluator>>("preferred"),
                 opts.get<int>("boost")),
-            false, nullptr, opts.get_list<shared_ptr<Evaluator>>("preferred"),
+            false, shared_ptr<TaskIndependentEvaluator>(nullptr), opts.get_list<shared_ptr<TaskIndependentEvaluator>>("preferred"),
             eager_search::get_eager_search_arguments_from_options(opts));
     }
 };

--- a/src/search/search_algorithms/plugin_eager_wastar.cc
+++ b/src/search/search_algorithms/plugin_eager_wastar.cc
@@ -7,14 +7,14 @@ using namespace std;
 
 namespace plugin_eager_wastar {
 class EagerWAstarSearchFeature
-    : public plugins::TypedFeature<SearchAlgorithm, eager_search::EagerSearch> {
+    : public plugins::TaskIndependentFeature<TaskIndependentSearchAlgorithm> {
 public:
-    EagerWAstarSearchFeature() : TypedFeature("eager_wastar") {
+    EagerWAstarSearchFeature() : TaskIndependentFeature("eager_wastar") {
         document_title("Eager weighted A* search");
         document_synopsis("");
 
-        add_list_option<shared_ptr<Evaluator>>("evals", "evaluators");
-        add_list_option<shared_ptr<Evaluator>>(
+        add_list_option<shared_ptr<TaskIndependentEvaluator>>("evals", "evaluators");
+        add_list_option<shared_ptr<TaskIndependentEvaluator>>(
             "preferred", "use preferred operators of these evaluators", "[]");
         add_option<bool>("reopen_closed", "reopen closed nodes", "true");
         add_option<int>(
@@ -34,17 +34,17 @@ public:
             "is **not** equivalent to\n```\n--search \"astar(h())\"\n```\n");
     }
 
-    virtual shared_ptr<eager_search::EagerSearch> create_component(
+    virtual shared_ptr<TaskIndependentSearchAlgorithm> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<eager_search::EagerSearch>(
+        return components::make_auto_task_independent_component<eager_search::EagerSearch, SearchAlgorithm>(
             search_common::create_wastar_open_list_factory(
-                opts.get_list<shared_ptr<Evaluator>>("evals"),
-                opts.get_list<shared_ptr<Evaluator>>("preferred"),
+                opts.get_list<shared_ptr<TaskIndependentEvaluator>>("evals"),
+                opts.get_list<shared_ptr<TaskIndependentEvaluator>>("preferred"),
                 opts.get<int>("boost"), opts.get<int>("w"),
                 opts.get<utils::Verbosity>("verbosity")),
             opts.get<bool>("reopen_closed"),
-            opts.get<shared_ptr<Evaluator>>("f_eval", nullptr),
-            opts.get_list<shared_ptr<Evaluator>>("preferred"),
+            opts.get<shared_ptr<TaskIndependentEvaluator>>("f_eval", nullptr),
+            opts.get_list<shared_ptr<TaskIndependentEvaluator>>("preferred"),
             eager_search::get_eager_search_arguments_from_options(opts));
     }
 };

--- a/src/search/search_algorithms/plugin_lazy.cc
+++ b/src/search/search_algorithms/plugin_lazy.cc
@@ -7,26 +7,26 @@ using namespace std;
 
 namespace plugin_lazy {
 class LazySearchFeature
-    : public plugins::TypedFeature<SearchAlgorithm, lazy_search::LazySearch> {
+    : public plugins::TaskIndependentFeature<TaskIndependentSearchAlgorithm> {
 public:
-    LazySearchFeature() : TypedFeature("lazy") {
+    LazySearchFeature() : TaskIndependentFeature("lazy") {
         document_title("Lazy best-first search");
         document_synopsis("");
 
-        add_option<shared_ptr<OpenListFactory>>("open", "open list");
+        add_option<shared_ptr<TaskIndependentOpenListFactory>>("open", "open list");
         add_option<bool>("reopen_closed", "reopen closed nodes", "false");
-        add_list_option<shared_ptr<Evaluator>>(
+        add_list_option<shared_ptr<TaskIndependentEvaluator>>(
             "preferred", "use preferred operators of these evaluators", "[]");
         add_successors_order_options_to_feature(*this);
         add_search_algorithm_options_to_feature(*this, "lazy");
     }
 
-    virtual shared_ptr<lazy_search::LazySearch> create_component(
+    virtual shared_ptr<TaskIndependentSearchAlgorithm> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<lazy_search::LazySearch>(
-            opts.get<shared_ptr<OpenListFactory>>("open"),
+        return components::make_auto_task_independent_component<lazy_search::LazySearch, SearchAlgorithm>(
+            opts.get<shared_ptr<TaskIndependentOpenListFactory>>("open"),
             opts.get<bool>("reopen_closed"),
-            opts.get_list<shared_ptr<Evaluator>>("preferred"),
+            opts.get_list<shared_ptr<TaskIndependentEvaluator>>("preferred"),
             get_successors_order_arguments_from_options(opts),
             get_search_algorithm_arguments_from_options(opts));
     }

--- a/src/search/search_algorithms/plugin_lazy_greedy.cc
+++ b/src/search/search_algorithms/plugin_lazy_greedy.cc
@@ -9,13 +9,13 @@ namespace plugin_lazy_greedy {
 static const string DEFAULT_LAZY_BOOST = "1000";
 
 class LazyGreedySearchFeature
-    : public plugins::TypedFeature<SearchAlgorithm, lazy_search::LazySearch> {
+    : public plugins::TaskIndependentFeature<TaskIndependentSearchAlgorithm> {
 public:
-    LazyGreedySearchFeature() : TypedFeature("lazy_greedy") {
+    LazyGreedySearchFeature() : TaskIndependentFeature("lazy_greedy") {
         document_title("Greedy search (lazy)");
         document_synopsis("");
 
-        add_list_option<shared_ptr<Evaluator>>("evals", "evaluators");
+        add_list_option<shared_ptr<TaskIndependentEvaluator>>("evals", "evaluators");
         add_option<int>(
             "boost",
             "boost value for alternation queues that are restricted "
@@ -23,7 +23,7 @@ public:
             DEFAULT_LAZY_BOOST);
 
         add_option<bool>("reopen_closed", "reopen closed nodes", "false");
-        add_list_option<shared_ptr<Evaluator>>(
+        add_list_option<shared_ptr<TaskIndependentEvaluator>>(
             "preferred", "use preferred operators of these evaluators", "[]");
         add_successors_order_options_to_feature(*this);
         add_search_algorithm_options_to_feature(*this, "lazy_greedy");
@@ -63,15 +63,15 @@ public:
             true);
     }
 
-    virtual shared_ptr<lazy_search::LazySearch> create_component(
+    virtual shared_ptr<TaskIndependentSearchAlgorithm> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<lazy_search::LazySearch>(
+        return components::make_auto_task_independent_component<lazy_search::LazySearch, SearchAlgorithm>(
             search_common::create_greedy_open_list_factory(
-                opts.get_list<shared_ptr<Evaluator>>("evals"),
-                opts.get_list<shared_ptr<Evaluator>>("preferred"),
+                opts.get_list<shared_ptr<TaskIndependentEvaluator>>("evals"),
+                opts.get_list<shared_ptr<TaskIndependentEvaluator>>("preferred"),
                 opts.get<int>("boost")),
             opts.get<bool>("reopen_closed"),
-            opts.get_list<shared_ptr<Evaluator>>("preferred"),
+            opts.get_list<shared_ptr<TaskIndependentEvaluator>>("preferred"),
             get_successors_order_arguments_from_options(opts),
             get_search_algorithm_arguments_from_options(opts));
     }

--- a/src/search/search_algorithms/plugin_lazy_wastar.cc
+++ b/src/search/search_algorithms/plugin_lazy_wastar.cc
@@ -9,15 +9,15 @@ namespace plugin_lazy_wastar {
 static const string DEFAULT_LAZY_BOOST = "1000";
 
 class LazyWAstarSearchFeature
-    : public plugins::TypedFeature<SearchAlgorithm, lazy_search::LazySearch> {
+    : public plugins::TaskIndependentFeature<TaskIndependentSearchAlgorithm> {
 public:
-    LazyWAstarSearchFeature() : TypedFeature("lazy_wastar") {
+    LazyWAstarSearchFeature() : TaskIndependentFeature("lazy_wastar") {
         document_title("(Weighted) A* search (lazy)");
         document_synopsis(
             "Weighted A* is a special case of lazy best first search.");
 
-        add_list_option<shared_ptr<Evaluator>>("evals", "evaluators");
-        add_list_option<shared_ptr<Evaluator>>(
+        add_list_option<shared_ptr<TaskIndependentEvaluator>>("evals", "evaluators");
+        add_list_option<shared_ptr<TaskIndependentEvaluator>>(
             "preferred", "use preferred operators of these evaluators", "[]");
         add_option<bool>("reopen_closed", "reopen closed nodes", "true");
         add_option<int>(
@@ -67,16 +67,16 @@ public:
             true);
     }
 
-    virtual shared_ptr<lazy_search::LazySearch> create_component(
+    virtual shared_ptr<TaskIndependentSearchAlgorithm> create_component(
         const plugins::Options &opts) const override {
-        return plugins::make_shared_from_arg_tuples<lazy_search::LazySearch>(
+        return components::make_auto_task_independent_component<lazy_search::LazySearch, SearchAlgorithm>(
             search_common::create_wastar_open_list_factory(
-                opts.get_list<shared_ptr<Evaluator>>("evals"),
-                opts.get_list<shared_ptr<Evaluator>>("preferred"),
+                opts.get_list<shared_ptr<TaskIndependentEvaluator>>("evals"),
+                opts.get_list<shared_ptr<TaskIndependentEvaluator>>("preferred"),
                 opts.get<int>("boost"), opts.get<int>("w"),
                 opts.get<utils::Verbosity>("verbosity")),
             opts.get<bool>("reopen_closed"),
-            opts.get_list<shared_ptr<Evaluator>>("preferred"),
+            opts.get_list<shared_ptr<TaskIndependentEvaluator>>("preferred"),
             get_successors_order_arguments_from_options(opts),
             get_search_algorithm_arguments_from_options(opts));
     }

--- a/src/search/search_algorithms/search_common.cc
+++ b/src/search/search_algorithms/search_common.cc
@@ -1,7 +1,5 @@
 #include "search_common.h"
 
-#include "../open_list_factory.h"
-
 #include "../evaluators/g_evaluator.h"
 #include "../evaluators/sum_evaluator.h"
 #include "../evaluators/weighted_evaluator.h"
@@ -23,34 +21,34 @@ using WeightedEval = weighted_evaluator::WeightedEvaluator;
   Helper function for common code of create_greedy_open_list_factory
   and create_wastar_open_list_factory.
 */
-static shared_ptr<OpenListFactory> create_alternation_open_list_factory_aux(
-    const vector<shared_ptr<Evaluator>> &evals,
-    const vector<shared_ptr<Evaluator>> &preferred_evaluators, int boost) {
+static shared_ptr<TaskIndependentOpenListFactory> create_alternation_open_list_factory_aux(
+    const vector<shared_ptr<TaskIndependentEvaluator>> &evals,
+    const vector<shared_ptr<TaskIndependentEvaluator>> &preferred_evaluators, int boost) {
     if (evals.size() == 1 && preferred_evaluators.empty()) {
-        return make_shared<standard_scalar_open_list::BestFirstOpenListFactory>(
+        return components::make_auto_task_independent_component<standard_scalar_open_list::BestFirstOpenListFactory, OpenListFactory>(
             evals[0], false);
     } else {
-        vector<shared_ptr<OpenListFactory>> subfactories;
-        for (const shared_ptr<Evaluator> &evaluator : evals) {
+        vector<shared_ptr<TaskIndependentOpenListFactory>> subfactories;
+        for (const shared_ptr<TaskIndependentEvaluator> &evaluator : evals) {
             subfactories.push_back(
-                make_shared<
-                    standard_scalar_open_list::BestFirstOpenListFactory>(
+                components::make_auto_task_independent_component<
+                    standard_scalar_open_list::BestFirstOpenListFactory, OpenListFactory>(
                     evaluator, false));
             if (!preferred_evaluators.empty()) {
                 subfactories.push_back(
-                    make_shared<
-                        standard_scalar_open_list::BestFirstOpenListFactory>(
+                    components::make_auto_task_independent_component<
+                        standard_scalar_open_list::BestFirstOpenListFactory, OpenListFactory>(
                         evaluator, true));
             }
         }
-        return make_shared<alternation_open_list::AlternationOpenListFactory>(
+        return components::make_auto_task_independent_component<alternation_open_list::AlternationOpenListFactory, OpenListFactory>(
             subfactories, boost);
     }
 }
 
-shared_ptr<OpenListFactory> create_greedy_open_list_factory(
-    const vector<shared_ptr<Evaluator>> &evals,
-    const vector<shared_ptr<Evaluator>> &preferred_evaluators, int boost) {
+shared_ptr<TaskIndependentOpenListFactory> create_greedy_open_list_factory(
+    const vector<shared_ptr<TaskIndependentEvaluator>> &evals,
+    const vector<shared_ptr<TaskIndependentEvaluator>> &preferred_evaluators, int boost) {
     utils::verify_list_not_empty(evals, "evals");
     return create_alternation_open_list_factory_aux(
         evals, preferred_evaluators, boost);
@@ -66,48 +64,48 @@ shared_ptr<OpenListFactory> create_greedy_open_list_factory(
   If w = 0, we omit the h-evaluator altogether:
   we use g instead of g + 0 * h.
 */
-static shared_ptr<Evaluator> create_wastar_eval(
-    utils::Verbosity verbosity, const shared_ptr<GEval> &g_eval, int weight,
-    const shared_ptr<Evaluator> &h_eval) {
+static shared_ptr<TaskIndependentEvaluator> create_wastar_eval(
+    utils::Verbosity verbosity, const shared_ptr<TaskIndependentEvaluator> &g_eval, int weight,
+    const shared_ptr<TaskIndependentEvaluator> &h_eval) {
     if (weight == 0) {
         return g_eval;
     }
-    shared_ptr<Evaluator> w_h_eval = nullptr;
+    shared_ptr<TaskIndependentEvaluator> w_h_eval = nullptr;
     if (weight == 1) {
         w_h_eval = h_eval;
     } else {
-        w_h_eval = make_shared<WeightedEval>(
+        w_h_eval = components::make_auto_task_independent_component<WeightedEval, Evaluator>(
             h_eval, weight, "wastar.w_h_eval", verbosity);
     }
-    return make_shared<SumEval>(
-        vector<shared_ptr<Evaluator>>({g_eval, w_h_eval}), "wastar.eval",
+    return components::make_auto_task_independent_component<SumEval, Evaluator>(
+        vector<shared_ptr<TaskIndependentEvaluator>>({g_eval, w_h_eval}), "wastar.eval",
         verbosity);
 }
 
-shared_ptr<OpenListFactory> create_wastar_open_list_factory(
-    const vector<shared_ptr<Evaluator>> &evals,
-    const vector<shared_ptr<Evaluator>> &preferred, int boost, int weight,
+shared_ptr<TaskIndependentOpenListFactory> create_wastar_open_list_factory(
+    const vector<shared_ptr<TaskIndependentEvaluator>> &evals,
+    const vector<shared_ptr<TaskIndependentEvaluator>> &preferred, int boost, int weight,
     utils::Verbosity verbosity) {
     utils::verify_list_not_empty(evals, "evals");
-    shared_ptr<GEval> g_eval = make_shared<GEval>("wastar.g_eval", verbosity);
-    vector<shared_ptr<Evaluator>> f_evals;
+    shared_ptr<TaskIndependentEvaluator> g_eval = components::make_auto_task_independent_component<GEval, Evaluator>("wastar.g_eval", verbosity);
+    vector<shared_ptr<TaskIndependentEvaluator>> f_evals;
     f_evals.reserve(evals.size());
-    for (const shared_ptr<Evaluator> &eval : evals)
+    for (const shared_ptr<TaskIndependentEvaluator> &eval : evals)
         f_evals.push_back(create_wastar_eval(verbosity, g_eval, weight, eval));
 
     return create_alternation_open_list_factory_aux(f_evals, preferred, boost);
 }
 
-pair<shared_ptr<OpenListFactory>, const shared_ptr<Evaluator>>
+pair<shared_ptr<TaskIndependentOpenListFactory>, const shared_ptr<TaskIndependentEvaluator>>
 create_astar_open_list_factory_and_f_eval(
-    const shared_ptr<Evaluator> &h_eval, utils::Verbosity verbosity) {
-    shared_ptr<GEval> g = make_shared<GEval>("astar.g_eval", verbosity);
-    shared_ptr<Evaluator> f = make_shared<SumEval>(
-        vector<shared_ptr<Evaluator>>({g, h_eval}), "astar.f_eval", verbosity);
-    vector<shared_ptr<Evaluator>> evals = {f, h_eval};
+    const shared_ptr<TaskIndependentEvaluator> &h_eval, utils::Verbosity verbosity) {
+    shared_ptr<TaskIndependentEvaluator> g = components::make_auto_task_independent_component<GEval, Evaluator>("astar.g_eval", verbosity);
+    shared_ptr<TaskIndependentEvaluator> f = components::make_auto_task_independent_component<SumEval, Evaluator>(
+        vector<shared_ptr<TaskIndependentEvaluator>>({g, h_eval}), "astar.f_eval", verbosity);
+    vector<shared_ptr<TaskIndependentEvaluator>> evals = {f, h_eval};
 
-    shared_ptr<OpenListFactory> open =
-        make_shared<tiebreaking_open_list::TieBreakingOpenListFactory>(
+    shared_ptr<TaskIndependentOpenListFactory> open =
+        components::make_auto_task_independent_component<tiebreaking_open_list::TieBreakingOpenListFactory, OpenListFactory>(
             evals, false, false);
     return make_pair(open, f);
 }

--- a/src/search/search_algorithms/search_common.h
+++ b/src/search/search_algorithms/search_common.h
@@ -18,13 +18,13 @@
   to eager and lazy search.
 */
 
+#include "../evaluator.h"
+#include "../open_list_factory.h"
+
 #include "../utils/logging.h"
 
 #include <memory>
 #include <vector>
-
-class Evaluator;
-class OpenListFactory;
 
 namespace search_common {
 /*
@@ -39,9 +39,9 @@ namespace search_common {
   for the alternation open list, then that sublist is returned
   directly.
 */
-extern std::shared_ptr<OpenListFactory> create_greedy_open_list_factory(
-    const std::vector<std::shared_ptr<Evaluator>> &evals,
-    const std::vector<std::shared_ptr<Evaluator>> &preferred_evaluators,
+extern std::shared_ptr<TaskIndependentOpenListFactory> create_greedy_open_list_factory(
+    const std::vector<std::shared_ptr<TaskIndependentEvaluator>> &evals,
+    const std::vector<std::shared_ptr<TaskIndependentEvaluator>> &preferred_evaluators,
     int boost);
 
 /*
@@ -51,9 +51,9 @@ extern std::shared_ptr<OpenListFactory> create_greedy_open_list_factory(
   documentation there), except that the open lists use evalators based
   on g + w * h rather than using h directly.
 */
-extern std::shared_ptr<OpenListFactory> create_wastar_open_list_factory(
-    const std::vector<std::shared_ptr<Evaluator>> &base_evals,
-    const std::vector<std::shared_ptr<Evaluator>> &preferred, int boost,
+extern std::shared_ptr<TaskIndependentOpenListFactory> create_wastar_open_list_factory(
+    const std::vector<std::shared_ptr<TaskIndependentEvaluator>> &base_evals,
+    const std::vector<std::shared_ptr<TaskIndependentEvaluator>> &preferred, int boost,
     int weight, utils::Verbosity verbosity);
 
 /*
@@ -64,9 +64,9 @@ extern std::shared_ptr<OpenListFactory> create_wastar_open_list_factory(
   ordered primarily on g + h and secondarily on h.
 */
 extern std::pair<
-    std::shared_ptr<OpenListFactory>, const std::shared_ptr<Evaluator>>
+    std::shared_ptr<TaskIndependentOpenListFactory>, const std::shared_ptr<TaskIndependentEvaluator>>
 create_astar_open_list_factory_and_f_eval(
-    const std::shared_ptr<Evaluator> &h_eval, utils::Verbosity verbosity);
+    const std::shared_ptr<TaskIndependentEvaluator> &h_eval, utils::Verbosity verbosity);
 }
 
 #endif


### PR DESCRIPTION
We split up the pull request of issue559 into 7 parts for easier reviewing.

This is the third one, containing mostly mechanical changes. It violates clang format intentionally for a smaller diff. The next commit after this runs clang format and the next PR is against the formatted code.

The code in `plugins` introduces `TaskIndependentFeature` and removes `TypedFeature` and some of its base classes.
The remaining changes are mechanical:

* All feature types (e.g., `Evaluator`)
    * Add `const shared_ptr<AbstractTask> &task` argument as first constructor arg, pass through and store in base class (not used except for in evaluators and search algorithms)
    * Derive from `TaskSpecificComponent`
    * Introduce alias (e.g., `using TaskIndependentEvaluator = TaskIndependentComponent<Evaluator>;`)

* All components (e.g., `FFHeuristic`):
    * Add `const shared_ptr<AbstractTask> &task` argument as first constructor arg, pass through and store in base class (not used except for in evaluators and search algorithms)
      * In evaluators: remove `transform` argument (use `task` from base class instead)

* All component features (e.g., `FFHeuristicFeature`):
    * Derive from `TaskIndependentFeature<T>` instead of `TypedFeature` (also removes some old code in `plugin.h`)
    * Some `get_*_arguments_from_options` change return types (task-specific to task-independent)
    * Return type of `create_component` is now not specifically typed (e.g., `TaskIndependentEvaluator` instead of `TaskIndependentFFHeuristic`)
    * use templated `make_auto_task_independent_component` to create the component