### PR TITLE
Issue559 - part 4

### DIFF
--- a/src/search/potentials/diverse_potential_heuristics.cc
+++ b/src/search/potentials/diverse_potential_heuristics.cc
@@ -16,10 +16,10 @@ using namespace std;
 
 namespace potentials {
 DiversePotentialHeuristics::DiversePotentialHeuristics(
-    int num_samples, int max_num_heuristics, double max_potential,
-    lp::LPSolverType lpsolver, const shared_ptr<AbstractTask> &transform,
+    const shared_ptr<AbstractTask> &task, int num_samples,
+    int max_num_heuristics, double max_potential, lp::LPSolverType lpsolver,
     int random_seed, utils::Verbosity verbosity)
-    : optimizer(transform, lpsolver, max_potential),
+    : optimizer(task, lpsolver, max_potential),
       max_num_heuristics(max_num_heuristics),
       num_samples(num_samples),
       rng(utils::get_rng(random_seed)),
@@ -150,10 +150,53 @@ DiversePotentialHeuristics::find_functions() {
     return move(diverse_functions);
 }
 
-class DiversePotentialMaxHeuristicFeature
-    : public plugins::TypedFeature<Evaluator, PotentialMaxHeuristic> {
+class TaskIndependentDiversePotentialHeuristics
+    : public TaskIndependentEvaluator {
+    int num_samples;
+    int max_num_heuristics;
+    double max_potential;
+    lp::LPSolverType lpsolver;
+    int random_seed;
+    bool cache_estimates;
+    string description;
+    utils::Verbosity verbosity;
+protected:
+    virtual shared_ptr<Evaluator> create_task_specific_component(
+        const shared_ptr<AbstractTask> &task) const override {
+        DiversePotentialHeuristics diverse_potential_heuristics(
+            task, num_samples, max_num_heuristics, max_potential, lpsolver,
+            random_seed, verbosity);
+        return make_shared<PotentialMaxHeuristic>(
+            task, diverse_potential_heuristics.find_functions(),
+            cache_estimates, description, verbosity);
+    }
 public:
-    DiversePotentialMaxHeuristicFeature() : TypedFeature("diverse_potentials") {
+    TaskIndependentDiversePotentialHeuristics(
+        int num_samples, int max_num_heuristics, double max_potential,
+        lp::LPSolverType lpsolver, int random_seed, bool cache_estimates,
+        const string &description, utils::Verbosity verbosity);
+};
+
+TaskIndependentDiversePotentialHeuristics::
+    TaskIndependentDiversePotentialHeuristics(
+        int num_samples, int max_num_heuristics, double max_potential,
+        lp::LPSolverType lpsolver, int random_seed, bool cache_estimates,
+        const string &description, utils::Verbosity verbosity)
+    : num_samples(num_samples),
+      max_num_heuristics(max_num_heuristics),
+      max_potential(max_potential),
+      lpsolver(lpsolver),
+      random_seed(random_seed),
+      cache_estimates(cache_estimates),
+      description(description),
+      verbosity(verbosity) {
+}
+
+class DiversePotentialMaxHeuristicFeature
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
+public:
+    DiversePotentialMaxHeuristicFeature()
+        : TaskIndependentFeature("diverse_potentials") {
         document_subcategory("heuristics_potentials");
         document_title("Diverse potential heuristics");
         document_synopsis(get_admissible_potentials_reference());
@@ -169,20 +212,14 @@ public:
         utils::add_rng_options_to_feature(*this);
     }
 
-    virtual shared_ptr<PotentialMaxHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return make_shared<PotentialMaxHeuristic>(
-            DiversePotentialHeuristics(
-                opts.get<int>("num_samples"),
-                opts.get<int>("max_num_heuristics"),
-                opts.get<double>("max_potential"),
-                opts.get<lp::LPSolverType>("lpsolver"),
-                opts.get<shared_ptr<AbstractTask>>("transform"),
-                opts.get<int>("random_seed"),
-                opts.get<utils::Verbosity>("verbosity"))
-                .find_functions(),
-            opts.get<shared_ptr<AbstractTask>>("transform"),
-            opts.get<bool>("cache_estimates"), opts.get<string>("description"),
+        return make_shared<TaskIndependentDiversePotentialHeuristics>(
+            opts.get<int>("num_samples"), opts.get<int>("max_num_heuristics"),
+            opts.get<double>("max_potential"),
+            opts.get<lp::LPSolverType>("lpsolver"),
+            opts.get<int>("random_seed"), opts.get<bool>("cache_estimates"),
+            opts.get<string>("description"),
             opts.get<utils::Verbosity>("verbosity"));
     }
 };

--- a/src/search/potentials/diverse_potential_heuristics.h
+++ b/src/search/potentials/diverse_potential_heuristics.h
@@ -55,11 +55,9 @@ class DiversePotentialHeuristics {
 
 public:
     DiversePotentialHeuristics(
-        int num_samples, int max_num_heuristics, double max_potential,
-        lp::LPSolverType lpsolver,
-        const std::shared_ptr<AbstractTask> &transform, int random_seed,
-        utils::Verbosity verbosity);
-    ~DiversePotentialHeuristics() = default;
+        const std::shared_ptr<AbstractTask> &task, int num_samples,
+        int max_num_heuristics, double max_potential, lp::LPSolverType lpsolver,
+        int random_seed, utils::Verbosity verbosity);
 
     // Sample states, then cover them.
     std::vector<std::unique_ptr<PotentialFunction>> find_functions();

--- a/src/search/potentials/potential_heuristic.cc
+++ b/src/search/potentials/potential_heuristic.cc
@@ -8,10 +8,10 @@ using namespace std;
 
 namespace potentials {
 PotentialHeuristic::PotentialHeuristic(
-    unique_ptr<PotentialFunction> function,
-    const shared_ptr<AbstractTask> &transform, bool cache_estimates,
+    const shared_ptr<AbstractTask> &task,
+    unique_ptr<PotentialFunction> function, bool cache_estimates,
     const string &description, utils::Verbosity verbosity)
-    : Heuristic(transform, cache_estimates, description, verbosity),
+    : Heuristic(task, cache_estimates, description, verbosity),
       function(move(function)) {
 }
 

--- a/src/search/potentials/potential_heuristic.h
+++ b/src/search/potentials/potential_heuristic.h
@@ -19,8 +19,8 @@ protected:
 
 public:
     explicit PotentialHeuristic(
-        std::unique_ptr<PotentialFunction> function,
-        const std::shared_ptr<AbstractTask> &transform, bool cache_estimates,
+        const std::shared_ptr<AbstractTask> &task,
+        std::unique_ptr<PotentialFunction> function, bool cache_estimates,
         const std::string &description, utils::Verbosity verbosity);
 };
 }

--- a/src/search/potentials/potential_max_heuristic.cc
+++ b/src/search/potentials/potential_max_heuristic.cc
@@ -8,10 +8,10 @@ using namespace std;
 
 namespace potentials {
 PotentialMaxHeuristic::PotentialMaxHeuristic(
-    vector<unique_ptr<PotentialFunction>> &&functions,
-    const shared_ptr<AbstractTask> &transform, bool cache_estimates,
+    const shared_ptr<AbstractTask> &task,
+    vector<unique_ptr<PotentialFunction>> &&functions, bool cache_estimates,
     const string &description, utils::Verbosity verbosity)
-    : Heuristic(transform, cache_estimates, description, verbosity),
+    : Heuristic(task, cache_estimates, description, verbosity),
       functions(move(functions)) {
 }
 

--- a/src/search/potentials/potential_max_heuristic.h
+++ b/src/search/potentials/potential_max_heuristic.h
@@ -20,9 +20,10 @@ protected:
 
 public:
     PotentialMaxHeuristic(
+        const std::shared_ptr<AbstractTask> &task,
         std::vector<std::unique_ptr<PotentialFunction>> &&functions,
-        const std::shared_ptr<AbstractTask> &transform, bool cache_estimates,
-        const std::string &description, utils::Verbosity verbosity);
+        bool cache_estimates, const std::string &description,
+        utils::Verbosity verbosity);
 };
 }
 

--- a/src/search/potentials/potential_optimizer.cc
+++ b/src/search/potentials/potential_optimizer.cc
@@ -19,9 +19,9 @@ static int get_undefined_value(VariableProxy var) {
 }
 
 PotentialOptimizer::PotentialOptimizer(
-    const shared_ptr<AbstractTask> &transform, lp::LPSolverType lpsolver,
+    const shared_ptr<AbstractTask> &task, lp::LPSolverType lpsolver,
     double max_potential)
-    : task(transform),
+    : task(task),
       task_proxy(*task),
       lp_solver(lpsolver),
       max_potential(max_potential),

--- a/src/search/potentials/potential_optimizer.h
+++ b/src/search/potentials/potential_optimizer.h
@@ -58,8 +58,8 @@ class PotentialOptimizer {
 
 public:
     PotentialOptimizer(
-        const std::shared_ptr<AbstractTask> &transform,
-        lp::LPSolverType lpsolver, double max_potential);
+        const std::shared_ptr<AbstractTask> &task, lp::LPSolverType lpsolver,
+        double max_potential);
     ~PotentialOptimizer() = default;
 
     std::shared_ptr<AbstractTask> get_task() const;

--- a/src/search/potentials/sample_based_potential_heuristics.cc
+++ b/src/search/potentials/sample_based_potential_heuristics.cc
@@ -42,11 +42,10 @@ static void optimize_for_samples(
 */
 static vector<unique_ptr<PotentialFunction>>
 create_sample_based_potential_functions(
-    int num_samples, int num_heuristics, double max_potential,
-    lp::LPSolverType lpsolver, const shared_ptr<AbstractTask> &transform,
-    int random_seed) {
+    const shared_ptr<AbstractTask> &task, int num_samples, int num_heuristics,
+    double max_potential, lp::LPSolverType lpsolver, int random_seed) {
     vector<unique_ptr<PotentialFunction>> functions;
-    PotentialOptimizer optimizer(transform, lpsolver, max_potential);
+    PotentialOptimizer optimizer(task, lpsolver, max_potential);
     shared_ptr<utils::RandomNumberGenerator> rng(utils::get_rng(random_seed));
     for (int i = 0; i < num_heuristics; ++i) {
         optimize_for_samples(optimizer, num_samples, *rng);
@@ -55,11 +54,48 @@ create_sample_based_potential_functions(
     return functions;
 }
 
+class TaskIndependentSampleBasedPotentialMaxHeuristic
+    : public TaskIndependentEvaluator {
+    int num_samples;
+    int num_heuristics;
+    double max_potential;
+    lp::LPSolverType lpsolver;
+    int random_seed;
+    bool cache_estimates;
+    string description;
+    utils::Verbosity verbosity;
+public:
+    TaskIndependentSampleBasedPotentialMaxHeuristic(
+        int num_samples, int num_heuristics, double max_potential,
+        lp::LPSolverType lpsolver, int random_seed, bool cache_estimates,
+        const string &description, utils::Verbosity verbosity)
+        : num_samples(num_samples),
+          num_heuristics(num_heuristics),
+          max_potential(max_potential),
+          lpsolver(lpsolver),
+          random_seed(random_seed),
+          cache_estimates(cache_estimates),
+          description(description),
+          verbosity(verbosity) {
+    }
+
+    virtual shared_ptr<Evaluator> create_task_specific_component(
+        const shared_ptr<AbstractTask> &task) const override {
+        vector<unique_ptr<PotentialFunction>> potential_functions =
+            create_sample_based_potential_functions(
+                task, num_samples, num_heuristics, max_potential, lpsolver,
+                random_seed);
+        return make_shared<PotentialMaxHeuristic>(
+            task, move(potential_functions), cache_estimates, description,
+            verbosity);
+    }
+};
+
 class SampleBasedPotentialMaxHeuristicFeature
-    : public plugins::TypedFeature<Evaluator, PotentialMaxHeuristic> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
     SampleBasedPotentialMaxHeuristicFeature()
-        : TypedFeature("sample_based_potentials") {
+        : TaskIndependentFeature("sample_based_potentials") {
         document_subcategory("heuristics_potentials");
         document_title("Sample-based potential heuristics");
         document_synopsis(
@@ -76,17 +112,14 @@ public:
         utils::add_rng_options_to_feature(*this);
     }
 
-    virtual shared_ptr<PotentialMaxHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return make_shared<PotentialMaxHeuristic>(
-            create_sample_based_potential_functions(
-                opts.get<int>("num_samples"), opts.get<int>("num_heuristics"),
-                opts.get<double>("max_potential"),
-                opts.get<lp::LPSolverType>("lpsolver"),
-                opts.get<shared_ptr<AbstractTask>>("transform"),
-                opts.get<int>("random_seed")),
-            opts.get<shared_ptr<AbstractTask>>("transform"),
-            opts.get<bool>("cache_estimates"), opts.get<string>("description"),
+        return make_shared<TaskIndependentSampleBasedPotentialMaxHeuristic>(
+            opts.get<int>("num_samples"), opts.get<int>("num_heuristics"),
+            opts.get<double>("max_potential"),
+            opts.get<lp::LPSolverType>("lpsolver"),
+            opts.get<int>("random_seed"), opts.get<bool>("cache_estimates"),
+            opts.get<string>("description"),
             opts.get<utils::Verbosity>("verbosity"));
     }
 };

--- a/src/search/potentials/single_potential_heuristics.cc
+++ b/src/search/potentials/single_potential_heuristics.cc
@@ -15,11 +15,10 @@ enum class OptimizeFor {
 };
 
 static unique_ptr<PotentialFunction> create_potential_function(
-    const shared_ptr<AbstractTask> &transform, lp::LPSolverType lpsolver,
+    const shared_ptr<AbstractTask> &task, lp::LPSolverType lpsolver,
     double max_potential, OptimizeFor opt_func) {
-    PotentialOptimizer optimizer(transform, lpsolver, max_potential);
-    const AbstractTask &task = *transform;
-    TaskProxy task_proxy(task);
+    PotentialOptimizer optimizer(task, lpsolver, max_potential);
+    TaskProxy task_proxy(*task);
     switch (opt_func) {
     case OptimizeFor::INITIAL_STATE:
         optimizer.optimize_for_state(task_proxy.get_initial_state());
@@ -33,11 +32,43 @@ static unique_ptr<PotentialFunction> create_potential_function(
     return optimizer.get_potential_function();
 }
 
+class TaskIndependentSinglePotentialHeuristic
+    : public TaskIndependentEvaluator {
+    lp::LPSolverType lpsolver;
+    double max_potential;
+    OptimizeFor opt_func;
+    bool cache_estimates;
+    string description;
+    utils::Verbosity verbosity;
+
+public:
+    TaskIndependentSinglePotentialHeuristic(
+        lp::LPSolverType lpsolver, double max_potential, OptimizeFor opt_func,
+        bool cache_estimates, const string &description,
+        utils::Verbosity verbosity)
+        : lpsolver(lpsolver),
+          max_potential(max_potential),
+          opt_func(opt_func),
+          cache_estimates(cache_estimates),
+          description(description),
+          verbosity(verbosity) {
+    }
+
+    virtual shared_ptr<Evaluator> create_task_specific_component(
+        const shared_ptr<AbstractTask> &task) const override {
+        unique_ptr<PotentialFunction> potential_function =
+            create_potential_function(task, lpsolver, max_potential, opt_func);
+        return make_shared<PotentialHeuristic>(
+            task, move(potential_function), cache_estimates, description,
+            verbosity);
+    }
+};
+
 class InitialStatePotentialHeuristicFeature
-    : public plugins::TypedFeature<Evaluator, PotentialHeuristic> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
     InitialStatePotentialHeuristicFeature()
-        : TypedFeature("initial_state_potential") {
+        : TaskIndependentFeature("initial_state_potential") {
         document_subcategory("heuristics_potentials");
         document_title("Potential heuristic optimized for initial state");
         document_synopsis(get_admissible_potentials_reference());
@@ -46,14 +77,11 @@ public:
             *this, "initial_state_potential");
     }
 
-    virtual shared_ptr<PotentialHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return make_shared<PotentialHeuristic>(
-            create_potential_function(
-                opts.get<shared_ptr<AbstractTask>>("transform"),
-                opts.get<lp::LPSolverType>("lpsolver"),
-                opts.get<double>("max_potential"), OptimizeFor::INITIAL_STATE),
-            opts.get<shared_ptr<AbstractTask>>("transform"),
+        return make_shared<TaskIndependentSinglePotentialHeuristic>(
+            opts.get<lp::LPSolverType>("lpsolver"),
+            opts.get<double>("max_potential"), OptimizeFor::INITIAL_STATE,
             opts.get<bool>("cache_estimates"), opts.get<string>("description"),
             opts.get<utils::Verbosity>("verbosity"));
     }
@@ -63,10 +91,10 @@ static plugins::FeaturePlugin<InitialStatePotentialHeuristicFeature>
     _plugin_initial_state;
 
 class AllStatesPotentialHeuristicFeature
-    : public plugins::TypedFeature<Evaluator, PotentialHeuristic> {
+    : public plugins::TaskIndependentFeature<TaskIndependentEvaluator> {
 public:
     AllStatesPotentialHeuristicFeature()
-        : TypedFeature("all_states_potential") {
+        : TaskIndependentFeature("all_states_potential") {
         document_subcategory("heuristics_potentials");
         document_title("Potential heuristic optimized for all states");
         document_synopsis(get_admissible_potentials_reference());
@@ -75,14 +103,11 @@ public:
             *this, "all_states_potential");
     }
 
-    virtual shared_ptr<PotentialHeuristic> create_component(
+    virtual shared_ptr<TaskIndependentEvaluator> create_component(
         const plugins::Options &opts) const override {
-        return make_shared<PotentialHeuristic>(
-            create_potential_function(
-                opts.get<shared_ptr<AbstractTask>>("transform"),
-                opts.get<lp::LPSolverType>("lpsolver"),
-                opts.get<double>("max_potential"), OptimizeFor::ALL_STATES),
-            opts.get<shared_ptr<AbstractTask>>("transform"),
+        return make_shared<TaskIndependentSinglePotentialHeuristic>(
+            opts.get<lp::LPSolverType>("lpsolver"),
+            opts.get<double>("max_potential"), OptimizeFor::ALL_STATES,
             opts.get<bool>("cache_estimates"), opts.get<string>("description"),
             opts.get<utils::Verbosity>("verbosity"));
     }

--- a/src/search/potentials/util.cc
+++ b/src/search/potentials/util.cc
@@ -64,9 +64,7 @@ void add_admissible_potentials_options_to_feature(
     add_heuristic_options_to_feature(feature, description);
 }
 
-tuple<
-    double, lp::LPSolverType, shared_ptr<AbstractTask>, bool, string,
-    utils::Verbosity>
+tuple<double, lp::LPSolverType, bool, string, utils::Verbosity>
 get_admissible_potential_arguments_from_options(const plugins::Options &opts) {
     return tuple_cat(
         make_tuple(opts.get<double>("max_potential")),

--- a/src/search/potentials/util.h
+++ b/src/search/potentials/util.h
@@ -30,9 +30,7 @@ std::vector<State> sample_without_dead_end_detection(
 std::string get_admissible_potentials_reference();
 void add_admissible_potentials_options_to_feature(
     plugins::Feature &feature, const std::string &description);
-std::tuple<
-    double, lp::LPSolverType, std::shared_ptr<AbstractTask>, bool, std::string,
-    utils::Verbosity>
+std::tuple<double, lp::LPSolverType, bool, std::string, utils::Verbosity>
 get_admissible_potential_arguments_from_options(const plugins::Options &opts);
 }
 


### PR DESCRIPTION
We split up the pull request of issue559 into 7 parts for easier reviewing.

This is the fourth one, dealing with a special case for potential heuristic which could not easily use the automatically generated task-independent component.